### PR TITLE
remove moq

### DIFF
--- a/HICPluginTests/HICPluginTests.csproj
+++ b/HICPluginTests/HICPluginTests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="3.1.15" />
   </ItemGroup>

--- a/HICPluginTests/Integration/SCIStoreCacheDestinationTests.cs
+++ b/HICPluginTests/Integration/SCIStoreCacheDestinationTests.cs
@@ -10,6 +10,7 @@ using SCIStorePlugin;
 using SCIStorePlugin.Cache.Pipeline;
 using SCIStorePlugin.Data;
 using Tests.Common;
+using NSubstitute;
 
 namespace SCIStorePluginTests.Integration;
 
@@ -71,7 +72,7 @@ public class SCIStoreCacheDestinationTests : DatabaseTests
         var deleteMe = LoadDirectory.CreateDirectoryStructure(new DirectoryInfo(TestContext.CurrentContext.WorkDirectory),"DeleteMe", true);
         try
         {
-            var fetchRequest = new Moq.Mock<ICacheFetchRequest>().Object;
+            var fetchRequest = Substitute.For<ICacheFetchRequest>();
 
             var cacheChunk = new SCIStoreCacheChunk(new[] { report }, fetchDate, fetchRequest)
             {

--- a/HICPluginTests/TicketFactoryTests.cs
+++ b/HICPluginTests/TicketFactoryTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Rdmp.Core.Ticketing;
 using Rdmp.Core.ReusableLibraryCode.DataAccess;
 using Tests.Common;
+using NSubstitute;
 
 namespace JiraPluginTests;
 
@@ -19,7 +20,7 @@ public class TicketFactoryTests : DatabaseTests
     [Test]
     public void FactoryCreateAJIRA()
     {
-        var credentials = new Moq.Mock<IDataAccessCredentials>().Object;
+        var credentials = Substitute.For<IDataAccessCredentials>();
         Assert.DoesNotThrow(() => TicketingSystemFactory.Create(typeof(JIRATicketingSystem).FullName, "Bob", credentials));
     }
 

--- a/HICPluginTests/Unit/LimitedRetryThenContinueStrategyTests.cs
+++ b/HICPluginTests/Unit/LimitedRetryThenContinueStrategyTests.cs
@@ -5,6 +5,7 @@ using Rdmp.Core.ReusableLibraryCode.Progress;
 using SCIStorePlugin.Data;
 using SCIStorePlugin.DataProvider.RetryStrategies;
 using SCIStorePlugin.Repositories;
+using NSubstitute;
 
 namespace SCIStorePluginTests.Unit;
 
@@ -13,7 +14,7 @@ public class LimitedRetryThenContinueStrategyTests
     [Test]
     public void Test()
     {
-        var mockServer = new Moq.Mock<IRepositorySupportsDateRangeQueries<CombinedReportData>>().Object;
+        var mockServer = Substitute.For<IRepositorySupportsDateRangeQueries<CombinedReportData>>();
 
         var strategy = new LimitedRetryThenContinueStrategy(5,new List<int>(new int[]{3,1}), mockServer);
 


### PR DESCRIPTION
This can probably wait till rc4 is out the door.
Replaces the light usage of Moq with NSubstitute