### PR TITLE
Bugfix/rdmp 136 chi columns

### DIFF
--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -1,14 +1,13 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using NPOI.OpenXmlFormats.Dml;
 using Rdmp.Core.CommandExecution;
 using Rdmp.Core.Curation.Data;
-using Rdmp.Core.DataExport.DataExtraction;
 using Rdmp.Core.DataExport.DataExtraction.Commands;
 using Rdmp.Core.DataFlowPipeline;
 using Rdmp.Core.DataFlowPipeline.Requirements;

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -40,6 +40,9 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
 
     public bool VerboseLogging { get; set; } = false;
 
+    [DemandsInitialization("The directory location to write the Found CHIs data to. Defaults to the extraction directory")]
+    public string LocationToWriteFoundCHIS { get; set; }
+
     private bool _firstTime = true;
 
     private bool _isTableAlreadyNamed;
@@ -71,9 +74,12 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
         string fileLocation = null;
         if (OutputFileDirectory?.Exists == true)
         {
-            var CHIDir = Path.Combine(OutputFileDirectory.FullName, "FoundCHIs");
+
+            var CHIDir = Path.Combine(string.IsNullOrWhiteSpace(LocationToWriteFoundCHIS) ? OutputFileDirectory.FullName : LocationToWriteFoundCHIS, "FoundCHIs");
             if (!Directory.Exists(CHIDir)) Directory.CreateDirectory(CHIDir);
             fileLocation = Path.Combine(CHIDir, $"{toProcess.TableName}{_potentialChiLocationFileDescriptor}");
+
+
             if (File.Exists(fileLocation) && BailOutAfter > 0)
             {
                 count = File.ReadLines(fileLocation).Count() - 1;

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -194,7 +194,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
         Complete
     }
 
-    private static string GetPotentialCHI(string toCheckStr)
+    private string GetPotentialCHI(string toCheckStr, IDataLoadEventListener listener )
     {
         if (string.IsNullOrWhiteSpace(toCheckStr) || toCheckStr.Length < 9) return "";
 
@@ -304,6 +304,8 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
             }
             catch (Exception)
             {
+                listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information,
+                                  $"We think there is a CHI in the string {toCheckStr} at index {indexOfDay}, but were inable to find it"));
                 return "Unable to find CHI";
             }
         }

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -151,7 +151,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
         if (count > 0 && OutputFileDirectory?.Exists == true)
         {
             var countWritten = BailOutAfter > 0 ? Math.Min(count, BailOutAfter) : count;
-            var location = (string.IsNullOrWhiteSpace(LocationToWriteFoundCHIS) ? OutputFileDirectory.FullName : LocationToWriteFoundCHIS;
+            var location = (string.IsNullOrWhiteSpace(LocationToWriteFoundCHIS) ? OutputFileDirectory.FullName : LocationToWriteFoundCHIS);
             listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, $"{countWritten} CHIs have been found in your extraction. Find them in {location}"));
             if (_activator is not null)
             {

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -62,20 +62,20 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
 
         List<string> columnGreenList = new();
         if (_allowLists.TryGetValue(RdmpAll, out var _extractionSpecificAllowances))
-                columnGreenList.AddRange(_extractionSpecificAllowances);
+            columnGreenList.AddRange(_extractionSpecificAllowances);
         if (_allowLists.TryGetValue(toProcess.TableName, out var _catalogueSpecificAllowances))
-                columnGreenList.AddRange(_catalogueSpecificAllowances.ToList());
+            columnGreenList.AddRange(_catalogueSpecificAllowances.ToList());
 
-        var count=0;
+        var count = 0;
         string fileLocation = null;
         if (OutputFileDirectory?.Exists == true)
         {
             var CHIDir = Path.Combine(OutputFileDirectory.FullName, "FoundCHIs");
             if (!Directory.Exists(CHIDir)) Directory.CreateDirectory(CHIDir);
             fileLocation = Path.Combine(CHIDir, $"{toProcess.TableName}{_potentialChiLocationFileDescriptor}");
-            if (File.Exists(fileLocation) && BailOutAfter>0)
+            if (File.Exists(fileLocation) && BailOutAfter > 0)
             {
-                count = File.ReadLines(fileLocation).Count()-1;
+                count = File.ReadLines(fileLocation).Count() - 1;
                 if (count > BailOutAfter)
                 {
                     if (VerboseLogging)
@@ -141,13 +141,13 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
             }
         }
 
-        if (count>0 && OutputFileDirectory?.Exists == true)
+        if (count > 0 && OutputFileDirectory?.Exists == true)
         {
             var countWritten = BailOutAfter > 0 ? Math.Min(count, BailOutAfter) : count;
             listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, $"{countWritten} CHIs have been found in your extraction. Find them in {OutputFileDirectory.FullName}"));
             if (_activator is not null)
             {
-                toProcess.ExtendedProperties.Add("AlertUIAtEndOfProcess", new Tuple<string,IBasicActivateItems>($"Some CHIs have been found in your extraction for the catalogue {toProcess.TableName}. Find them in {OutputFileDirectory.FullName}.",_activator));
+                toProcess.ExtendedProperties.Add("AlertUIAtEndOfProcess", new Tuple<string, IBasicActivateItems>($"Some CHIs have been found in your extraction for the catalogue {toProcess.TableName}. Find them in {OutputFileDirectory.FullName}.", _activator));
             }
         }
         return toProcess;
@@ -194,7 +194,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
         Complete
     }
 
-    private string GetPotentialCHI(string toCheckStr, IDataLoadEventListener listener )
+    private string GetPotentialCHI(string toCheckStr, IDataLoadEventListener listener)
     {
         if (string.IsNullOrWhiteSpace(toCheckStr) || toCheckStr.Length < 9) return "";
 
@@ -216,8 +216,8 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
                     case State.Day1: // Might be a 9 digit "CHI" with leading zero removed
                     case State.Complete:
                         state = State.End;
-                        if (ValidBits(day, month, year, check))
-                            return toCheckStr.Substring(i + 1, 9);
+                        if (ValidBits(day, month, year, check) && i+1 <= toCheckStr.Length)
+                            return toCheckStr.Substring(i + 1, Math.Min(9,toCheckStr.Length));
 
                         break;
 
@@ -296,7 +296,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
                     break;
             }
         }
-        if(ValidBits(day, month, year, check))
+        if (ValidBits(day, month, year, check))
         {
             try
             {

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -113,7 +113,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
                     Interlocked.Increment(ref count);
                     if (BailOutAfter > 0 && count > BailOutAfter) break;
 
-                    listFile.Value?.WriteLine($"{col.ColumnName},{GetPotentialCHI(val)},{val}");
+                    listFile.Value?.WriteLine($"{col.ColumnName},{GetPotentialCHI(val, listener)},{val}");
                     if (VerboseLogging || string.IsNullOrWhiteSpace(fileLocation))
                     {
                         listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Warning,

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -296,7 +296,19 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
                     break;
             }
         }
-        return ValidBits(day, month, year, check) ? toCheckStr.Substring(indexOfDay, Math.Min(10,toCheckStr.Length)) : "";
+        if(ValidBits(day, month, year, check))
+        {
+            try
+            {
+                return toCheckStr.Substring(indexOfDay, Math.Min(10, toCheckStr.Length));
+            }
+            catch (Exception)
+            {
+                return "Unable to find CHI";
+            }
+        }
+        return "";
+        //return ValidBits(day, month, year, check) ? toCheckStr.Substring(indexOfDay, Math.Min(10, toCheckStr.Length)) : "";
     }
 
     private static bool ContainsValidChi([CanBeNull] object toCheck)

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -29,7 +29,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
     [DemandsInitialization("A Yaml file that outlines which columns in which catalogues can be safely ignored")]
     public string AllowListFile { get; set; }
 
-    private DirectoryInfo OutputFileDirectory;
+    private DirectoryInfo _outputFileDirectory;
 
     [DemandsInitialization("If non-zero, will stop searching for CHIs after it has found that many of them in the extraction.", DefaultValue = 0)]
 
@@ -46,7 +46,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
 
     private const string RdmpAll = "RDMP_ALL";
     private readonly string _potentialChiLocationFileDescriptor = "_Potential_CHI_Locations.csv";
-    private string ExtractionIdentifier;
+    private string _extractionIdentifier;
     private readonly string _csvColumns = "Column,Potential CHI,Value";
     private IBasicActivateItems _activator;
 
@@ -69,12 +69,12 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
 
         var count = 0;
         string fileLocation = null;
-        if (OutputFileDirectory?.Exists == true)
+        if (_outputFileDirectory?.Exists == true)
         {
 
-            var CHIDir = Path.Combine(OutputFileDirectory.FullName, "FoundCHIs");
+            var CHIDir = Path.Combine(_outputFileDirectory.FullName, "FoundCHIs");
             if (!Directory.Exists(CHIDir)) Directory.CreateDirectory(CHIDir);
-            fileLocation = Path.Combine(CHIDir, $"{ExtractionIdentifier}_{toProcess.TableName}{_potentialChiLocationFileDescriptor}");
+            fileLocation = Path.Combine(CHIDir, $"{_extractionIdentifier}_{toProcess.TableName}{_potentialChiLocationFileDescriptor}");
 
 
             if (File.Exists(fileLocation) && BailOutAfter > 0)
@@ -145,10 +145,10 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
             }
         }
 
-        if (count > 0 && OutputFileDirectory?.Exists == true)
+        if (count > 0 && _outputFileDirectory?.Exists == true)
         {
             var countWritten = BailOutAfter > 0 ? Math.Min(count, BailOutAfter) : count;
-            var location = (OutputFileDirectory.FullName );
+            var location = _outputFileDirectory.FullName;
             listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, $"{countWritten} CHIs have been found in your extraction. Find them in {location}"));
             if (_activator is not null)
             {
@@ -420,8 +420,8 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
     {
         if (value is not ExtractDatasetCommand edcs) return;
 
-        OutputFileDirectory = edcs.GetExtractionDirectory()?.Parent?.Parent;
-        ExtractionIdentifier = edcs.GetExtractionDirectory()?.Parent.Name;
+        _outputFileDirectory = edcs.GetExtractionDirectory()?.Parent?.Parent;
+        _extractionIdentifier = edcs.GetExtractionDirectory()?.Parent.Name;
         try
         {
             var hashOnReleaseColumns = edcs.Catalogue.CatalogueItems.Select(static ci => ci.ExtractionInformation)

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -305,7 +305,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
             catch (Exception)
             {
                 listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information,
-                                  $"We think there is a CHI in the string {toCheckStr} at index {indexOfDay}, but were inable to find it"));
+                                  $"We think there is a CHI in the string {toCheckStr} at index {indexOfDay}, but were unable to find it"));
                 return "Unable to find CHI";
             }
         }

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -195,7 +195,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
         Complete
     }
 
-    private static string WithMaxLength(string value, int startIndex,int maxLength)
+    private static string WithMaxLength(string value, int startIndex, int maxLength)
     {
         return value?.Substring(startIndex, Math.Min(maxLength, value.Length - startIndex));
     }
@@ -301,10 +301,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
                     break;
             }
         }
-        if (ValidBits(day, month, year, check))
-        {
-            return WithMaxLength(toCheckStr, indexOfDay, 10);
-        }
+        if (ValidBits(day, month, year, check)) return WithMaxLength(toCheckStr, indexOfDay, 10);
         return "";
     }
 

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -426,7 +426,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
         var x = (ExtractionDirectory)edcs.Directory;
         listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, x.ToString()));
 
-        OutputFileDirectory = ((ExtractionDirectory)edcs.Directory).GetRootExtractionDirectory();
+        OutputFileDirectory = edcs.Directory.GetGlobalsDirectory().Parent.Parent;
         listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "end"));
         try
         {

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -303,7 +303,6 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
         }
         if (ValidBits(day, month, year, check))
         {
-            Console.WriteLine(WithMaxLength(toCheckStr, indexOfDay, 10));
             return WithMaxLength(toCheckStr, indexOfDay, 10);
         }
         return "";

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -48,6 +48,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
 
     private const string RdmpAll = "RDMP_ALL";
     private readonly string _potentialChiLocationFileDescriptor = "_Potential_CHI_Locations.csv";
+    private string ExtractionIdentifier;
     private readonly string _csvColumns = "Column,Potential CHI,Value";
     private IBasicActivateItems _activator;
 
@@ -75,7 +76,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
 
             var CHIDir = Path.Combine(OutputFileDirectory.FullName, "FoundCHIs");
             if (!Directory.Exists(CHIDir)) Directory.CreateDirectory(CHIDir);
-            fileLocation = Path.Combine(CHIDir, $"{toProcess.TableName}{_potentialChiLocationFileDescriptor}");
+            fileLocation = Path.Combine(CHIDir, $"{ExtractionIdentifier}_{toProcess.TableName}{_potentialChiLocationFileDescriptor}");
 
 
             if (File.Exists(fileLocation) && BailOutAfter > 0)
@@ -422,6 +423,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
         if (value is not ExtractDatasetCommand edcs) return;
 
         OutputFileDirectory = edcs.GetExtractionDirectory()?.Parent?.Parent;
+        ExtractionIdentifier = edcs.GetExtractionDirectory()?.Parent.Name;
         try
         {
             var hashOnReleaseColumns = edcs.Catalogue.CatalogueItems.Select(static ci => ci.ExtractionInformation)

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -151,10 +151,11 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
         if (count > 0 && OutputFileDirectory?.Exists == true)
         {
             var countWritten = BailOutAfter > 0 ? Math.Min(count, BailOutAfter) : count;
-            listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, $"{countWritten} CHIs have been found in your extraction. Find them in {OutputFileDirectory.FullName}"));
+            var location = (string.IsNullOrWhiteSpace(LocationToWriteFoundCHIS) ? OutputFileDirectory.FullName : LocationToWriteFoundCHIS;
+            listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, $"{countWritten} CHIs have been found in your extraction. Find them in {location}"));
             if (_activator is not null)
             {
-                toProcess.ExtendedProperties.Add("AlertUIAtEndOfProcess", new Tuple<string, IBasicActivateItems>($"Some CHIs have been found in your extraction for the catalogue {toProcess.TableName}. Find them in {OutputFileDirectory.FullName}.", _activator));
+                toProcess.ExtendedProperties.Add("AlertUIAtEndOfProcess", new Tuple<string, IBasicActivateItems>($"Some CHIs have been found in your extraction for the catalogue {toProcess.TableName}. Find them in {location}.", _activator));
             }
         }
         return toProcess;

--- a/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
+++ b/HICPlugin/DataFlowComponents/CHIColumnFinder.cs
@@ -421,13 +421,7 @@ public sealed partial class CHIColumnFinder : IPluginDataFlowComponent<DataTable
     {
         if (value is not ExtractDatasetCommand edcs) return;
 
-        //OutputFileDirectory = ((ExtractionDirectory)edcs.Directory).ExtractionDirectoryInfo; //todo this isn't the root dir
-        listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "starting"));
-        var x = (ExtractionDirectory)edcs.Directory;
-        listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, x.ToString()));
-
-        OutputFileDirectory = edcs.Directory.GetGlobalsDirectory().Parent.Parent;
-        listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "end"));
+        OutputFileDirectory = edcs.GetExtractionDirectory()?.Parent?.Parent;
         try
         {
             var hashOnReleaseColumns = edcs.Catalogue.CatalogueItems.Select(static ci => ci.ExtractionInformation)

--- a/HICPlugin/Documentation/AllowList.yml
+++ b/HICPlugin/Documentation/AllowList.yml
@@ -1,0 +1,5 @@
+﻿
+RDMP_ALL:
+    - id
+Biochemistry:
+    - SampleType    

--- a/HICPlugin/Documentation/ChiColumnFinder.md
+++ b/HICPlugin/Documentation/ChiColumnFinder.md
@@ -1,0 +1,36 @@
+﻿## CHI Column Finder
+
+The CHI Column Finder is a an extraction pipeline step to find and redact potential CHIs in the extraction data.
+
+By default it scans all cells in your export tables for a potential CHI and writes any potential CHI to a file in your extraction directory.
+If any potential CHI are found, a warning message will appear at the end of your extraction.
+
+## Using the CHI Column Finder Efficiently
+Looking for CHI is an expensive process as we need to look in every cell of data in the extraction. The CHI column finder has some built-in configuration options to make this as pain-free as possible.
+
+### Override Until
+Allows for this step to be skipped until a certain point in time.
+
+### AllowList File
+The allow list provides the ability to add columns to ignore when searching for CHIs, such as UID columns and other generated fields.
+It supports a global allow list across all catalogues, but also a per catalogue allow list.
+
+A sample allow list might look like
+```
+RDMP_ALL:
+	- UUID
+	- BOOLEAN_FIELD
+MY_CATALOGUE:
+	- ANOTHER_UUID
+```
+This allow list would ignore all columns named 'UUID' and 'BOOLEAN_FIELD' in your extraction along with the column 'ANOTHER_FIELD' in the MY_CATALOGUE catalogue.
+
+
+Ax example file can be found [here](./AllowList.yml).
+
+### Bail Out After
+This option allows for the extraction to stop looking for CHIs after it has found a set number (0 means it will not stop searching early). 
+
+### Verbose Logging
+Checking this option will log any potential CHI to the extraction notification window as well as the 'Found CHI' file.
+

--- a/HICPluginTests/AttacherTests.cs
+++ b/HICPluginTests/AttacherTests.cs
@@ -117,7 +117,7 @@ public class AttacherTests : DatabaseTests
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
 
-            Assert.AreEqual($"No files found in ForLoading: {loadDirectory.ForLoading}", ex?.Message);
+            Assert.Equals($"No files found in ForLoading: {loadDirectory.ForLoading}", ex?.Message);
         }
         finally
         {
@@ -171,7 +171,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-            Assert.AreEqual(ex?.Message, "SecureLocalScratchArea is not empty, please ensure it is empty before attempting to attach.");
+            Assert.Equals(ex?.Message, "SecureLocalScratchArea is not empty, please ensure it is empty before attempting to attach.");
         }
         finally
         {
@@ -198,7 +198,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-            Assert.AreEqual("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png", ex?.Message);
+            Assert.Equals("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png", ex?.Message);
         }
         finally
         {
@@ -224,7 +224,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-            Assert.AreEqual("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png", ex?.Message);
+            Assert.Equals("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png", ex?.Message);
         }
         finally
         {
@@ -259,10 +259,10 @@ public class AttacherTests : DatabaseTests
             attacher.LoadCompletedSoDispose(ExitCodeType.Success, ThrowImmediatelyDataLoadEventListener.Quiet);
 
             // Should now only be the CSV file in ForLoading (which would be archived during the real load process)
-            Assert.IsTrue(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)));
+            Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)), Is.True);
 
             // Should be three zip files in the archive
-            Assert.AreEqual(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
+            Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
                 archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
                     .Select(f => f.Name).ToArray());
         }
@@ -327,10 +327,10 @@ public class AttacherTests : DatabaseTests
             attacher.LoadCompletedSoDispose(ExitCodeType.Success, ThrowImmediatelyDataLoadEventListener.Quiet);
 
             // Should now only be the CSV file in ForLoading (which would be archived during the real load process)
-            Assert.IsTrue(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)));
+            Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)),Is.True);
 
             // Should be three zip files in the archive
-            Assert.AreEqual(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
+            Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
                 archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
                     .Select(f => f.Name).ToArray());
         }
@@ -442,7 +442,7 @@ public class AttacherTests : DatabaseTests
             var ex = Assert.Throws<InvalidOperationException>(() => integrityChecker.VerifyIntegrityOfStrippedImages(archiveProvider, imageDir.FullName, ThrowImmediatelyDataLoadEventListener.Quiet),
                 "The image pixel data does not match so this method should throw. Otherwise it is reporting that there is no integrity problem when there is one.");
 
-            Assert.IsTrue(ex?.Message.Contains("The pixel byte array lengths are different"));
+            Assert.That(ex?.Message.Contains("The pixel byte array lengths are different"), Is.True);
             Console.WriteLine(ex?.Message);
         }
         finally
@@ -464,8 +464,8 @@ public class AttacherTests : DatabaseTests
             RarHelper.ExtractMultiVolumeArchive(testDir);
 
             // Now check we have the correct files
-            Assert.AreEqual(2, testDir.EnumerateFiles("*.jpeg").Count());
-            Assert.AreEqual(2, testDir.EnumerateFiles("*.png").Count());
+            Assert.Equals(2, testDir.EnumerateFiles("*.jpeg").Count());
+            Assert.Equals(2, testDir.EnumerateFiles("*.png").Count());
 
         }
         finally
@@ -492,18 +492,18 @@ public class AttacherTests : DatabaseTests
                 imgFile.Delete();
             }
 
-            Assert.AreEqual(4, testDir.EnumerateFiles().Count());
+            Assert.Equals(4, testDir.EnumerateFiles().Count());
 
             var processor = new ImageArchiveProcessor(testDir, testDir, 1);
             processor.ArchiveImagesForStorage(ThrowImmediatelyDataLoadEventListener.Quiet, 1024 * 1024);
 
             var imageDirPath = Path.Combine(testDir.FullName, "1");
-            Assert.IsTrue(Directory.Exists(imageDirPath));
+            Assert.That(Directory.Exists(imageDirPath), Is.True);
 
             var remainingFiles = Directory.EnumerateFiles(imageDirPath).ToList();
-            Assert.AreEqual(3, remainingFiles.Count);
-            Assert.AreEqual(3, remainingFiles.Count(f => Path.GetExtension(f) == ".tar"));
-            Assert.AreEqual(new[] { "1_1.tar", "1_2.tar", "1_3.tar" }, remainingFiles.Select(Path.GetFileName).ToArray());
+            Assert.Equals(3, remainingFiles.Count);
+            Assert.Equals(3, remainingFiles.Count(f => Path.GetExtension(f) == ".tar"));
+            Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" }, remainingFiles.Select(Path.GetFileName).ToArray());
         }
         finally
         {
@@ -563,8 +563,8 @@ public class AttacherTests : DatabaseTests
             attacher.Attach(_job, new GracefulCancellationToken());
             attacher.LoadCompletedSoDispose(ExitCodeType.Success, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-            Assert.AreEqual(3, archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count(),
-                "There should be 3 zip files in the archive directory.");
+            Assert.Equals(3, archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count());//,
+                // "There should be 3 zip files in the archive directory.");
 
             // Check that the ImageArchiveUriColumn has been updated in the database
             var uriListFromDatabase = new List<string>();
@@ -586,7 +586,7 @@ public class AttacherTests : DatabaseTests
                 @"1\1_2.tar!2_2345678901_2016-05-18_LM_2_PW1024_PH768.png"
             };
 
-            Assert.IsTrue(!expectedUriList.Except(uriListFromDatabase).Any());
+            Assert.That(!expectedUriList.Except(uriListFromDatabase).Any(), Is.True);
         }
         finally
         {

--- a/HICPluginTests/AttacherTests.cs
+++ b/HICPluginTests/AttacherTests.cs
@@ -117,7 +117,7 @@ public class AttacherTests : DatabaseTests
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
 
-            Assert.Equals($"No files found in ForLoading: {loadDirectory.ForLoading}", ex?.Message);
+           // Assert.Equals($"No files found in ForLoading: {loadDirectory.ForLoading}", ex?.Message);
         }
         finally
         {
@@ -171,7 +171,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-            Assert.Equals(ex?.Message, "SecureLocalScratchArea is not empty, please ensure it is empty before attempting to attach.");
+           // Assert.Equals(ex?.Message, "SecureLocalScratchArea is not empty, please ensure it is empty before attempting to attach.");
         }
         finally
         {
@@ -198,7 +198,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-            Assert.Equals("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png", ex?.Message);
+           // Assert.Equals("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png", ex?.Message);
         }
         finally
         {
@@ -224,7 +224,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-            Assert.Equals("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png", ex?.Message);
+           // Assert.Equals("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png", ex?.Message);
         }
         finally
         {
@@ -262,7 +262,7 @@ public class AttacherTests : DatabaseTests
             Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)), Is.True);
 
             // Should be three zip files in the archive
-            Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
+           // Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
                 archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
                     .Select(f => f.Name).ToArray());
         }
@@ -330,7 +330,7 @@ public class AttacherTests : DatabaseTests
             Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)),Is.True);
 
             // Should be three zip files in the archive
-            Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
+           // Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
                 archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
                     .Select(f => f.Name).ToArray());
         }
@@ -464,8 +464,8 @@ public class AttacherTests : DatabaseTests
             RarHelper.ExtractMultiVolumeArchive(testDir);
 
             // Now check we have the correct files
-            Assert.Equals(2, testDir.EnumerateFiles("*.jpeg").Count());
-            Assert.Equals(2, testDir.EnumerateFiles("*.png").Count());
+           // Assert.Equals(2, testDir.EnumerateFiles("*.jpeg").Count());
+           // Assert.Equals(2, testDir.EnumerateFiles("*.png").Count());
 
         }
         finally
@@ -492,7 +492,7 @@ public class AttacherTests : DatabaseTests
                 imgFile.Delete();
             }
 
-            Assert.Equals(4, testDir.EnumerateFiles().Count());
+           // Assert.Equals(4, testDir.EnumerateFiles().Count());
 
             var processor = new ImageArchiveProcessor(testDir, testDir, 1);
             processor.ArchiveImagesForStorage(ThrowImmediatelyDataLoadEventListener.Quiet, 1024 * 1024);
@@ -501,9 +501,9 @@ public class AttacherTests : DatabaseTests
             Assert.That(Directory.Exists(imageDirPath), Is.True);
 
             var remainingFiles = Directory.EnumerateFiles(imageDirPath).ToList();
-            Assert.Equals(3, remainingFiles.Count);
-            Assert.Equals(3, remainingFiles.Count(f => Path.GetExtension(f) == ".tar"));
-            Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" }, remainingFiles.Select(Path.GetFileName).ToArray());
+           // Assert.Equals(3, remainingFiles.Count);
+           // Assert.Equals(3, remainingFiles.Count(f => Path.GetExtension(f) == ".tar"));
+           // Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" }, remainingFiles.Select(Path.GetFileName).ToArray());
         }
         finally
         {
@@ -563,7 +563,7 @@ public class AttacherTests : DatabaseTests
             attacher.Attach(_job, new GracefulCancellationToken());
             attacher.LoadCompletedSoDispose(ExitCodeType.Success, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-            Assert.Equals(3, archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count());//,
+           // Assert.Equals(3, archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count());//,
                 // "There should be 3 zip files in the archive directory.");
 
             // Check that the ImageArchiveUriColumn has been updated in the database

--- a/HICPluginTests/AttacherTests.cs
+++ b/HICPluginTests/AttacherTests.cs
@@ -198,7 +198,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-            Assert.Equals("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png", Is.EqualTo(ex?.Message));
+            Assert.That("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png", Is.EqualTo(ex?.Message));
         }
         finally
         {
@@ -224,7 +224,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-           Assert.That("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png", Is.EqualTo(ex?.Message)_;
+           Assert.That("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png", Is.EqualTo(ex?.Message));
         }
         finally
         {

--- a/HICPluginTests/AttacherTests.cs
+++ b/HICPluginTests/AttacherTests.cs
@@ -563,8 +563,7 @@ public class AttacherTests : DatabaseTests
             attacher.Attach(_job, new GracefulCancellationToken());
             attacher.LoadCompletedSoDispose(ExitCodeType.Success, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-           Assert.That(3, Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count()));//,
-                // "There should be 3 zip files in the archive directory.");
+           Assert.That(3, Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count()));
 
             // Check that the ImageArchiveUriColumn has been updated in the database
             var uriListFromDatabase = new List<string>();

--- a/HICPluginTests/AttacherTests.cs
+++ b/HICPluginTests/AttacherTests.cs
@@ -117,7 +117,7 @@ public class AttacherTests : DatabaseTests
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
 
-           // Assert.Equals($"No files found in ForLoading: {loadDirectory.ForLoading}", ex?.Message);
+           Assert.That($"No files found in ForLoading: {loadDirectory.ForLoading}", Is.EqualTo(ex?.Message));
         }
         finally
         {
@@ -171,7 +171,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-           // Assert.Equals(ex?.Message, "SecureLocalScratchArea is not empty, please ensure it is empty before attempting to attach.");
+           Assert.That(ex?.Message, Is.EqualTo("SecureLocalScratchArea is not empty, please ensure it is empty before attempting to attach."));
         }
         finally
         {
@@ -198,7 +198,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-           // Assert.Equals("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png", ex?.Message);
+            Assert.Equals("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png", Is.EqualTo(ex?.Message));
         }
         finally
         {
@@ -224,7 +224,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-           // Assert.Equals("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png", ex?.Message);
+           Assert.That("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png", Is.EqualTo(ex?.Message)_;
         }
         finally
         {
@@ -262,9 +262,9 @@ public class AttacherTests : DatabaseTests
             Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)), Is.True);
 
             // Should be three zip files in the archive
-           // Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
-                archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
-                    .Select(f => f.Name).ToArray());
+           Assert.That(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
+                Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
+                    .Select(f => f.Name).ToArray()));
         }
         finally
         {
@@ -330,9 +330,9 @@ public class AttacherTests : DatabaseTests
             Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)),Is.True);
 
             // Should be three zip files in the archive
-           // Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
-                archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
-                    .Select(f => f.Name).ToArray());
+            Assert.That(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
+                Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
+                    .Select(f => f.Name).ToArray()));
         }
         finally
         {
@@ -464,8 +464,8 @@ public class AttacherTests : DatabaseTests
             RarHelper.ExtractMultiVolumeArchive(testDir);
 
             // Now check we have the correct files
-           // Assert.Equals(2, testDir.EnumerateFiles("*.jpeg").Count());
-           // Assert.Equals(2, testDir.EnumerateFiles("*.png").Count());
+           Assert.That(2, Is.EqualTo(testDir.EnumerateFiles("*.jpeg").Count()));
+           Assert.That(2, Is.EqualTo(testDir.EnumerateFiles("*.png").Count()));
 
         }
         finally
@@ -492,7 +492,7 @@ public class AttacherTests : DatabaseTests
                 imgFile.Delete();
             }
 
-           // Assert.Equals(4, testDir.EnumerateFiles().Count());
+            Assert.That(4, Is.EqualTo(testDir.EnumerateFiles().Count()));
 
             var processor = new ImageArchiveProcessor(testDir, testDir, 1);
             processor.ArchiveImagesForStorage(ThrowImmediatelyDataLoadEventListener.Quiet, 1024 * 1024);
@@ -501,9 +501,9 @@ public class AttacherTests : DatabaseTests
             Assert.That(Directory.Exists(imageDirPath), Is.True);
 
             var remainingFiles = Directory.EnumerateFiles(imageDirPath).ToList();
-           // Assert.Equals(3, remainingFiles.Count);
-           // Assert.Equals(3, remainingFiles.Count(f => Path.GetExtension(f) == ".tar"));
-           // Assert.Equals(new[] { "1_1.tar", "1_2.tar", "1_3.tar" }, remainingFiles.Select(Path.GetFileName).ToArray());
+            Assert.That(3, Is.EqualTo(remainingFiles.Count));
+            Assert.That(3, Is.EqualTo(remainingFiles.Count(f => Path.GetExtension(f) == ".tar")));
+            Assert.That(new[] { "1_1.tar", "1_2.tar", "1_3.tar" }, Is.EqualTo(remainingFiles.Select(Path.GetFileName).ToArray()));
         }
         finally
         {
@@ -563,7 +563,7 @@ public class AttacherTests : DatabaseTests
             attacher.Attach(_job, new GracefulCancellationToken());
             attacher.LoadCompletedSoDispose(ExitCodeType.Success, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-           // Assert.Equals(3, archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count());//,
+           Assert.That(3, Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count()));//,
                 // "There should be 3 zip files in the archive directory.");
 
             // Check that the ImageArchiveUriColumn has been updated in the database

--- a/HICPluginTests/AttacherTests.cs
+++ b/HICPluginTests/AttacherTests.cs
@@ -198,7 +198,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-            Assert.That("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png", Is.EqualTo(ex?.Message));
+            Assert.That(ex?.Message, Is.EqualTo("These files are specified in the manifest but are not present in the archive: 2_2345678901_2016-05-19_RM_1_PW1024_PH768.png"));
         }
         finally
         {
@@ -224,7 +224,7 @@ public class AttacherTests : DatabaseTests
             attacher.Initialize(loadDirectory, db);
 
             var ex = Assert.Throws<Exception>(() => attacher.Check(ThrowImmediatelyCheckNotifier.Quiet));
-           Assert.That("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png", Is.EqualTo(ex?.Message));
+            Assert.That(ex?.Message, Is.EqualTo("These files are present in the archive but are not specified in the manifest: 2_2345678901_2016-05-18_LM_2_PW1024_PH768.png"));
         }
         finally
         {
@@ -258,13 +258,16 @@ public class AttacherTests : DatabaseTests
             attacher.Attach(_job,new GracefulCancellationToken());
             attacher.LoadCompletedSoDispose(ExitCodeType.Success, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-            // Should now only be the CSV file in ForLoading (which would be archived during the real load process)
-            Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)), Is.True);
+            Assert.Multiple(() =>
+            {
+                // Should now only be the CSV file in ForLoading (which would be archived during the real load process)
+                Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)), Is.True);
 
-            // Should be three zip files in the archive
-           Assert.That(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
-                Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
-                    .Select(f => f.Name).ToArray()));
+                // Should be three zip files in the archive
+                Assert.That(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
+                    Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
+                        .Select(static f => f.Name).ToArray()));
+            });
         }
         finally
         {
@@ -326,13 +329,16 @@ public class AttacherTests : DatabaseTests
             attacher.Attach(_job,new GracefulCancellationToken());
             attacher.LoadCompletedSoDispose(ExitCodeType.Success, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-            // Should now only be the CSV file in ForLoading (which would be archived during the real load process)
-            Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)),Is.True);
+            Assert.Multiple(() =>
+            {
+                // Should now only be the CSV file in ForLoading (which would be archived during the real load process)
+                Assert.That(File.Exists(Path.Combine(loadDirectory.ForLoading.FullName, attacher.ManifestFileName)), Is.True);
 
-            // Should be three zip files in the archive
-            Assert.That(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
-                Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
-                    .Select(f => f.Name).ToArray()));
+                // Should be three zip files in the archive
+                Assert.That(new[] { "1_1.tar", "1_2.tar", "1_3.tar" },
+                    Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories)
+                        .Select(static f => f.Name).ToArray()));
+            });
         }
         finally
         {
@@ -463,10 +469,12 @@ public class AttacherTests : DatabaseTests
 
             RarHelper.ExtractMultiVolumeArchive(testDir);
 
-            // Now check we have the correct files
-           Assert.That(2, Is.EqualTo(testDir.EnumerateFiles("*.jpeg").Count()));
-           Assert.That(2, Is.EqualTo(testDir.EnumerateFiles("*.png").Count()));
-
+            Assert.Multiple(() =>
+            {
+                // Now check we have the correct files
+                Assert.That(testDir.EnumerateFiles("*.jpeg").Count(), Is.EqualTo(2));
+                Assert.That(testDir.EnumerateFiles("*.png").Count(), Is.EqualTo(2));
+            });
         }
         finally
         {
@@ -492,7 +500,7 @@ public class AttacherTests : DatabaseTests
                 imgFile.Delete();
             }
 
-            Assert.That(4, Is.EqualTo(testDir.EnumerateFiles().Count()));
+            Assert.That(testDir.EnumerateFiles().Count(), Is.EqualTo(4));
 
             var processor = new ImageArchiveProcessor(testDir, testDir, 1);
             processor.ArchiveImagesForStorage(ThrowImmediatelyDataLoadEventListener.Quiet, 1024 * 1024);
@@ -501,9 +509,12 @@ public class AttacherTests : DatabaseTests
             Assert.That(Directory.Exists(imageDirPath), Is.True);
 
             var remainingFiles = Directory.EnumerateFiles(imageDirPath).ToList();
-            Assert.That(3, Is.EqualTo(remainingFiles.Count));
-            Assert.That(3, Is.EqualTo(remainingFiles.Count(f => Path.GetExtension(f) == ".tar")));
-            Assert.That(new[] { "1_1.tar", "1_2.tar", "1_3.tar" }, Is.EqualTo(remainingFiles.Select(Path.GetFileName).ToArray()));
+            Assert.Multiple(() =>
+            {
+                Assert.That(remainingFiles, Has.Count.EqualTo(3));
+                Assert.That(remainingFiles.Count(static f => Path.GetExtension(f) == ".tar"), Is.EqualTo(3));
+                Assert.That(new[] { "1_1.tar", "1_2.tar", "1_3.tar" }, Is.EqualTo(remainingFiles.Select(Path.GetFileName).ToArray()));
+            });
         }
         finally
         {
@@ -563,7 +574,7 @@ public class AttacherTests : DatabaseTests
             attacher.Attach(_job, new GracefulCancellationToken());
             attacher.LoadCompletedSoDispose(ExitCodeType.Success, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-           Assert.That(3, Is.EqualTo(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count()));
+            Assert.That(archiveDir.EnumerateFiles("*.tar", SearchOption.AllDirectories).Count(), Is.EqualTo(3));
 
             // Check that the ImageArchiveUriColumn has been updated in the database
             var uriListFromDatabase = new List<string>();

--- a/HICPluginTests/ExtractionTests.cs
+++ b/HICPluginTests/ExtractionTests.cs
@@ -39,7 +39,7 @@ public class ExtractionTests : DatabaseTests
         var replacer = new DRSFilenameReplacer(extractionIdentifierColumn, "Image_Filename");
 
         string[] renameParams = {"Examination_Date", "Image_Num"};
-        Assert.Equals("R00001_2016-05-17_1.png", replacer.GetCorrectFilename(dataset.Rows[0],renameParams,null));
+       // Assert.Equals("R00001_2016-05-17_1.png", replacer.GetCorrectFilename(dataset.Rows[0],renameParams,null));
     }
 
     [Test]
@@ -96,8 +96,8 @@ public class ExtractionTests : DatabaseTests
             Assert.That(imageDir, Is.Not.Null);// "Extraction directory to hold images has not been created");
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
-            Assert.Equals(1, imageFiles.Count);
-            Assert.Equals("R00001_2016-05-17_1.png", imageFiles[0].Name);
+           // Assert.Equals(1, imageFiles.Count);
+           // Assert.Equals("R00001_2016-05-17_1.png", imageFiles[0].Name);
 
             Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
         }
@@ -174,8 +174,8 @@ public class ExtractionTests : DatabaseTests
             Assert.That(imageDir, Is.Not.Null);// "Extraction directory to hold images has not been created");
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
-            Assert.Equals(1, imageFiles.Count);
-            Assert.Equals("R00001_2016-05-17_1.png", imageFiles[0].Name);
+           // Assert.Equals(1, imageFiles.Count);
+           // Assert.Equals("R00001_2016-05-17_1.png", imageFiles[0].Name);
 
             Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
         }

--- a/HICPluginTests/ExtractionTests.cs
+++ b/HICPluginTests/ExtractionTests.cs
@@ -39,7 +39,7 @@ public class ExtractionTests : DatabaseTests
         var replacer = new DRSFilenameReplacer(extractionIdentifierColumn, "Image_Filename");
 
         string[] renameParams = {"Examination_Date", "Image_Num"};
-       Assert.That("R00001_2016-05-17_1.png", Is.EqualTo(replacer.GetCorrectFilename(dataset.Rows[0],renameParams,null)));
+        Assert.That(replacer.GetCorrectFilename(dataset.Rows[0], renameParams, null), Is.EqualTo("R00001_2016-05-17_1.png"));
     }
 
     [Test]
@@ -96,10 +96,12 @@ public class ExtractionTests : DatabaseTests
             Assert.That(imageDir, Is.Not.Null);
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
-           Assert.That(1, Is.EqualTo(imageFiles.Count));
-           Assert.That("R00001_2016-05-17_1.png", Is.EqualTo(imageFiles[0].Name));
-
-            Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
+            Assert.Multiple(() =>
+            {
+                Assert.That(imageFiles, Has.Count.EqualTo(1));
+                Assert.That(imageFiles[0].Name, Is.EqualTo("R00001_2016-05-17_1.png"));
+                Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
+            });
         }
         catch (Exception)
         {
@@ -122,12 +124,10 @@ public class ExtractionTests : DatabaseTests
 
         using (var fs = File.Create(Path.Combine(archiveSubdir.FullName, "1.tar")))
         {
-            using (var archive = TarArchive.CreateOutputTarArchive(fs))
-            {
-                var entry = TarEntry.CreateEntryFromFile(imagePath);
-                entry.Name = Path.GetFileName(imagePath);
-                archive.WriteEntry(entry, false);
-            }
+            using var archive = TarArchive.CreateOutputTarArchive(fs);
+            var entry = TarEntry.CreateEntryFromFile(imagePath);
+            entry.Name = Path.GetFileName(imagePath);
+            archive.WriteEntry(entry, false);
         }
 
         var rootDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
@@ -174,10 +174,13 @@ public class ExtractionTests : DatabaseTests
             Assert.That(imageDir, Is.Not.Null);
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
-           Assert.That(1, Is.EqualTo(imageFiles.Count));
-           Assert.That("R00001_2016-05-17_1.png", Is.EqualTo(imageFiles[0].Name));
+            Assert.Multiple(() =>
+            {
+                Assert.That(imageFiles, Has.Count.EqualTo(1));
+                Assert.That(imageFiles[0].Name, Is.EqualTo("R00001_2016-05-17_1.png"));
 
-            Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
+                Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
+            });
         }
         catch (Exception)
         {

--- a/HICPluginTests/ExtractionTests.cs
+++ b/HICPluginTests/ExtractionTests.cs
@@ -93,7 +93,7 @@ public class ExtractionTests : DatabaseTests
             var dt = extractionComponent.ProcessPipelineData(dataset, listener, cts.Token);
 
             var imageDir = rootDir.EnumerateDirectories("Images").SingleOrDefault();
-            Assert.That(imageDir, Is.Not.Null);// "Extraction directory to hold images has not been created");
+            Assert.That(imageDir, Is.Not.Null);
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
            Assert.That(1, Is.EqualTo(imageFiles.Count));
@@ -171,7 +171,7 @@ public class ExtractionTests : DatabaseTests
             var dt = extractionComponent.ProcessPipelineData(dataset, listener, cts.Token);
 
             var imageDir = rootDir.EnumerateDirectories("Images").SingleOrDefault();
-            Assert.That(imageDir, Is.Not.Null);// "Extraction directory to hold images has not been created");
+            Assert.That(imageDir, Is.Not.Null);
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
            Assert.That(1, Is.EqualTo(imageFiles.Count));

--- a/HICPluginTests/ExtractionTests.cs
+++ b/HICPluginTests/ExtractionTests.cs
@@ -39,7 +39,7 @@ public class ExtractionTests : DatabaseTests
         var replacer = new DRSFilenameReplacer(extractionIdentifierColumn, "Image_Filename");
 
         string[] renameParams = {"Examination_Date", "Image_Num"};
-       // Assert.Equals("R00001_2016-05-17_1.png", replacer.GetCorrectFilename(dataset.Rows[0],renameParams,null));
+       Assert.That("R00001_2016-05-17_1.png", Is.EqualTo(replacer.GetCorrectFilename(dataset.Rows[0],renameParams,null)));
     }
 
     [Test]
@@ -96,8 +96,8 @@ public class ExtractionTests : DatabaseTests
             Assert.That(imageDir, Is.Not.Null);// "Extraction directory to hold images has not been created");
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
-           // Assert.Equals(1, imageFiles.Count);
-           // Assert.Equals("R00001_2016-05-17_1.png", imageFiles[0].Name);
+           Assert.That(1, Is.EqualTo(imageFiles.Count));
+           Assert.That("R00001_2016-05-17_1.png", Is.EqualTo(imageFiles[0].Name));
 
             Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
         }
@@ -174,8 +174,8 @@ public class ExtractionTests : DatabaseTests
             Assert.That(imageDir, Is.Not.Null);// "Extraction directory to hold images has not been created");
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
-           // Assert.Equals(1, imageFiles.Count);
-           // Assert.Equals("R00001_2016-05-17_1.png", imageFiles[0].Name);
+           Assert.That(1, Is.EqualTo(imageFiles.Count));
+           Assert.That("R00001_2016-05-17_1.png", Is.EqualTo(imageFiles[0].Name));
 
             Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
         }

--- a/HICPluginTests/ExtractionTests.cs
+++ b/HICPluginTests/ExtractionTests.cs
@@ -39,7 +39,7 @@ public class ExtractionTests : DatabaseTests
         var replacer = new DRSFilenameReplacer(extractionIdentifierColumn, "Image_Filename");
 
         string[] renameParams = {"Examination_Date", "Image_Num"};
-        Assert.AreEqual("R00001_2016-05-17_1.png", replacer.GetCorrectFilename(dataset.Rows[0],renameParams,null));
+        Assert.Equals("R00001_2016-05-17_1.png", replacer.GetCorrectFilename(dataset.Rows[0],renameParams,null));
     }
 
     [Test]
@@ -93,13 +93,13 @@ public class ExtractionTests : DatabaseTests
             var dt = extractionComponent.ProcessPipelineData(dataset, listener, cts.Token);
 
             var imageDir = rootDir.EnumerateDirectories("Images").SingleOrDefault();
-            Assert.NotNull(imageDir, "Extraction directory to hold images has not been created");
+            Assert.That(imageDir, Is.Not.Null);// "Extraction directory to hold images has not been created");
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
-            Assert.AreEqual(1, imageFiles.Count);
-            Assert.AreEqual("R00001_2016-05-17_1.png", imageFiles[0].Name);
+            Assert.Equals(1, imageFiles.Count);
+            Assert.Equals("R00001_2016-05-17_1.png", imageFiles[0].Name);
 
-            Assert.IsFalse(dt.Columns.Contains("ImageArchiveUri"));
+            Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
         }
         catch (Exception)
         {
@@ -171,13 +171,13 @@ public class ExtractionTests : DatabaseTests
             var dt = extractionComponent.ProcessPipelineData(dataset, listener, cts.Token);
 
             var imageDir = rootDir.EnumerateDirectories("Images").SingleOrDefault();
-            Assert.NotNull(imageDir, "Extraction directory to hold images has not been created");
+            Assert.That(imageDir, Is.Not.Null);// "Extraction directory to hold images has not been created");
 
             var imageFiles = imageDir.EnumerateFiles().ToList();
-            Assert.AreEqual(1, imageFiles.Count);
-            Assert.AreEqual("R00001_2016-05-17_1.png", imageFiles[0].Name);
+            Assert.Equals(1, imageFiles.Count);
+            Assert.Equals("R00001_2016-05-17_1.png", imageFiles[0].Name);
 
-            Assert.IsFalse(dt.Columns.Contains("ImageArchiveUri"));
+            Assert.That(dt.Columns.Contains("ImageArchiveUri"), Is.False);
         }
         catch (Exception)
         {

--- a/HICPluginTests/HICPluginTests.csproj
+++ b/HICPluginTests/HICPluginTests.csproj
@@ -13,6 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="3.1.15" />
   </ItemGroup>

--- a/HICPluginTests/HICPluginTests.csproj
+++ b/HICPluginTests/HICPluginTests.csproj
@@ -11,7 +11,7 @@
     <None Remove="TestData\report-with-multiple-descriptions.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/HICPluginTests/Integration/CacheLayoutTests.cs
+++ b/HICPluginTests/Integration/CacheLayoutTests.cs
@@ -43,7 +43,7 @@ class CacheLayoutTests : DatabaseTests
         var downloadDirectory = cacheLayout.GetLoadCacheDirectory(ThrowImmediatelyDataLoadEventListener.Quiet);
 
         var expectedDownloadPath = Path.Combine(rootDirectory.FullName, "T", "Biochemistry");
-        Assert.AreEqual(expectedDownloadPath, downloadDirectory.FullName);
+        Assert.Equals(expectedDownloadPath, downloadDirectory.FullName);
     }
 
     [Test]
@@ -58,16 +58,16 @@ class CacheLayoutTests : DatabaseTests
         cacheLayout.CreateIfNotExists(ThrowImmediatelyDataLoadEventListener.Quiet);
 
         var expectedDownloadDirectory = new DirectoryInfo(Path.Combine(cacheDirectory.FullName, "T", "Biochemistry"));
-        Assert.IsTrue(expectedDownloadDirectory.Exists, "The cache has not created directory into which the individual report files will be copied");
+        Assert.That(expectedDownloadDirectory.Exists, Is.True);//"The cache has not created directory into which the individual report files will be copied");
 
         // stick some dummy files in the directory and check if archiving works
         File.WriteAllText(Path.Combine(expectedDownloadDirectory.FullName, "12345.xml"), "Test");
 
         cacheLayout.CreateArchive(fetchDate);
         var archiveFile = cacheLayout.GetArchiveFileInfoForDate(fetchDate, ThrowImmediatelyDataLoadEventListener.Quiet);
-        Assert.IsTrue(archiveFile.Exists);
+        Assert.That(archiveFile.Exists,Is.True);
 
         const string expectedArchiveFilename = "2005-01-01.zip";
-        Assert.AreEqual(expectedArchiveFilename, archiveFile.Name);
+        Assert.Equals(expectedArchiveFilename, archiveFile.Name);
     }
 }

--- a/HICPluginTests/Integration/CacheLayoutTests.cs
+++ b/HICPluginTests/Integration/CacheLayoutTests.cs
@@ -43,7 +43,7 @@ class CacheLayoutTests : DatabaseTests
         var downloadDirectory = cacheLayout.GetLoadCacheDirectory(ThrowImmediatelyDataLoadEventListener.Quiet);
 
         var expectedDownloadPath = Path.Combine(rootDirectory.FullName, "T", "Biochemistry");
-        Assert.Equals(expectedDownloadPath, downloadDirectory.FullName);
+       // Assert.Equals(expectedDownloadPath, downloadDirectory.FullName);
     }
 
     [Test]
@@ -68,6 +68,6 @@ class CacheLayoutTests : DatabaseTests
         Assert.That(archiveFile.Exists,Is.True);
 
         const string expectedArchiveFilename = "2005-01-01.zip";
-        Assert.Equals(expectedArchiveFilename, archiveFile.Name);
+       // Assert.Equals(expectedArchiveFilename, archiveFile.Name);
     }
 }

--- a/HICPluginTests/Integration/CacheLayoutTests.cs
+++ b/HICPluginTests/Integration/CacheLayoutTests.cs
@@ -43,7 +43,7 @@ class CacheLayoutTests : DatabaseTests
         var downloadDirectory = cacheLayout.GetLoadCacheDirectory(ThrowImmediatelyDataLoadEventListener.Quiet);
 
         var expectedDownloadPath = Path.Combine(rootDirectory.FullName, "T", "Biochemistry");
-       // Assert.Equals(expectedDownloadPath, downloadDirectory.FullName);
+       Assert.That(expectedDownloadPath, Is.EqualTo(downloadDirectory.FullName));
     }
 
     [Test]
@@ -68,6 +68,6 @@ class CacheLayoutTests : DatabaseTests
         Assert.That(archiveFile.Exists,Is.True);
 
         const string expectedArchiveFilename = "2005-01-01.zip";
-       // Assert.Equals(expectedArchiveFilename, archiveFile.Name);
+       Assert.That(expectedArchiveFilename, Is.EqualTo(archiveFile.Name));
     }
 }

--- a/HICPluginTests/Integration/CacheLayoutTests.cs
+++ b/HICPluginTests/Integration/CacheLayoutTests.cs
@@ -58,7 +58,7 @@ class CacheLayoutTests : DatabaseTests
         cacheLayout.CreateIfNotExists(ThrowImmediatelyDataLoadEventListener.Quiet);
 
         var expectedDownloadDirectory = new DirectoryInfo(Path.Combine(cacheDirectory.FullName, "T", "Biochemistry"));
-        Assert.That(expectedDownloadDirectory.Exists, Is.True);//"The cache has not created directory into which the individual report files will be copied");
+        Assert.That(expectedDownloadDirectory.Exists, Is.True);
 
         // stick some dummy files in the directory and check if archiving works
         File.WriteAllText(Path.Combine(expectedDownloadDirectory.FullName, "12345.xml"), "Test");

--- a/HICPluginTests/Integration/ChrisHallSpecialExplicitSourceTests.cs
+++ b/HICPluginTests/Integration/ChrisHallSpecialExplicitSourceTests.cs
@@ -22,6 +22,6 @@ class ChrisHallSpecialExplicitSourceTests:TestsRequiringAnExtractionConfiguratio
         source.PreInitialize(_request,ThrowImmediatelyDataLoadEventListener.Quiet);
 
         var chunk = source.GetChunk(ThrowImmediatelyDataLoadEventListener.Quiet, new GracefulCancellationToken());
-        Assert.NotNull(chunk);
+        Assert.That(chunk, Is.Not.Null);
     }
 }

--- a/HICPluginTests/Integration/ContextTests.cs
+++ b/HICPluginTests/Integration/ContextTests.cs
@@ -120,6 +120,6 @@ public class ContextTests : DatabaseTests
         if (_setupException != null)
             throw new Exception("Crashed during setup",_setupException);
 
-        Assert.IsNotNull(_pipelineDatabaseHelper.Pipe);
+        Assert.That(_pipelineDatabaseHelper.Pipe,Is.Not.Null);
     }
 }

--- a/HICPluginTests/Integration/HICCohortDestinationTest.cs
+++ b/HICPluginTests/Integration/HICCohortDestinationTest.cs
@@ -71,7 +71,7 @@ create procedure fishfishfishproc1
             //actually does the send
             d.Dispose(tomem,null);
 
-            Assert.AreEqual(cohortIDInTestData, request.CohortCreatedIfAny.OriginID);
+            Assert.Equals(cohortIDInTestData, request.CohortCreatedIfAny.OriginID);
         }
         else
             Assert.Throws<Exception>(() => d.Dispose(tomem, null));

--- a/HICPluginTests/Integration/HICCohortDestinationTest.cs
+++ b/HICPluginTests/Integration/HICCohortDestinationTest.cs
@@ -71,7 +71,7 @@ create procedure fishfishfishproc1
             //actually does the send
             d.Dispose(tomem,null);
 
-           // Assert.Equals(cohortIDInTestData, request.CohortCreatedIfAny.OriginID);
+           Assert.That(cohortIDInTestData, Is.EqualTo(request.CohortCreatedIfAny.OriginID));
         }
         else
             Assert.Throws<Exception>(() => d.Dispose(tomem, null));

--- a/HICPluginTests/Integration/HICCohortDestinationTest.cs
+++ b/HICPluginTests/Integration/HICCohortDestinationTest.cs
@@ -71,7 +71,7 @@ create procedure fishfishfishproc1
             //actually does the send
             d.Dispose(tomem,null);
 
-            Assert.Equals(cohortIDInTestData, request.CohortCreatedIfAny.OriginID);
+           // Assert.Equals(cohortIDInTestData, request.CohortCreatedIfAny.OriginID);
         }
         else
             Assert.Throws<Exception>(() => d.Dispose(tomem, null));

--- a/HICPluginTests/Integration/ReflectionToDatabaseTester.cs
+++ b/HICPluginTests/Integration/ReflectionToDatabaseTester.cs
@@ -58,7 +58,7 @@ public class ReflectionToDatabaseTester : DatabaseTests
         try
         {
             var ex = Assert.Throws<Exception>(() => ReflectionBasedSqlDatabaseInserter.MakeInsertSqlAndExecute<TestObject>(t, con, dbInfo, "TestObject"));
-            Assert.IsTrue(ex?.Message.Contains("Field1 in table TestObject is defined as length  10 in the database but you tried to insert a string value of length 41"));
+            Assert.That(ex?.Message.Contains("Field1 in table TestObject is defined as length  10 in the database but you tried to insert a string value of length 41"),Is.True);
         }
         finally
         {
@@ -94,7 +94,7 @@ public class ReflectionToDatabaseTester : DatabaseTests
         try
         {
             var ex = Assert.Throws<Exception>(() => ReflectionBasedSqlDatabaseInserter.MakeInsertSqlAndExecute(t, con, dbInfo, "TestObject"));
-            Assert.IsTrue(ex?.Message.Contains("Domain object has a property called Field2 which does not exist in table TestObject"));
+            Assert.That(ex?.Message.Contains("Domain object has a property called Field2 which does not exist in table TestObject"),Is.True);
         }
         finally
         {

--- a/HICPluginTests/Integration/ReflectionToDatabaseTester.cs
+++ b/HICPluginTests/Integration/ReflectionToDatabaseTester.cs
@@ -58,7 +58,7 @@ public class ReflectionToDatabaseTester : DatabaseTests
         try
         {
             var ex = Assert.Throws<Exception>(() => ReflectionBasedSqlDatabaseInserter.MakeInsertSqlAndExecute<TestObject>(t, con, dbInfo, "TestObject"));
-            Assert.That(ex?.Message.Contains("Field1 in table TestObject is defined as length  10 in the database but you tried to insert a string value of length 41"),Is.True);
+            Assert.That(ex?.Message.Contains("Field1 in table TestObject is defined as length 10 in the database but you tried to insert a string value of length 41"),Is.True);
         }
         finally
         {

--- a/HICPluginTests/Integration/SCIStoreCacheDestinationTests.cs
+++ b/HICPluginTests/Integration/SCIStoreCacheDestinationTests.cs
@@ -86,15 +86,17 @@ public class SCIStoreCacheDestinationTests : DatabaseTests
 
             var downloadDir = Path.Combine(rootDirectory.FullName, "T", "Biochemistry");
             var expectedArchiveFilepath = Path.Combine(downloadDir, "2015-01-01.zip");
-            Assert.That(File.Exists(expectedArchiveFilepath),Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(File.Exists(expectedArchiveFilepath), Is.True);
 
-            // make sure that the archiver has cleaned up after itself
-            Assert.That(Directory.EnumerateFiles(downloadDir, "*.xml"), Is.Empty);
+                // make sure that the archiver has cleaned up after itself
+                Assert.That(Directory.EnumerateFiles(downloadDir, "*.xml"), Is.Empty);
+            });
         }
         finally
         {
-            Directory.Delete(deleteMe.RootPath.FullName,true);
-
+            Directory.Delete(deleteMe.RootPath.FullName, true);
         }
     }
 

--- a/HICPluginTests/Integration/SCIStoreCacheDestinationTests.cs
+++ b/HICPluginTests/Integration/SCIStoreCacheDestinationTests.cs
@@ -86,10 +86,10 @@ public class SCIStoreCacheDestinationTests : DatabaseTests
 
             var downloadDir = Path.Combine(rootDirectory.FullName, "T", "Biochemistry");
             var expectedArchiveFilepath = Path.Combine(downloadDir, "2015-01-01.zip");
-            Assert.IsTrue(File.Exists(expectedArchiveFilepath));
+            Assert.That(File.Exists(expectedArchiveFilepath),Is.True);
 
             // make sure that the archiver has cleaned up after itself
-            Assert.IsEmpty(Directory.EnumerateFiles(downloadDir, "*.xml"));
+            Assert.That(Directory.EnumerateFiles(downloadDir, "*.xml"), Is.Empty);
         }
         finally
         {

--- a/HICPluginTests/Integration/SCIStoreDataTests.cs
+++ b/HICPluginTests/Integration/SCIStoreDataTests.cs
@@ -29,10 +29,10 @@ public class SCIStoreDataTests
         var reportFactory = new SciStoreReportFactory(readCodeConstraint);
         var report = reportFactory.Create(data, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-       // Assert.Equals(7, report.Samples.Count);
+       Assert.That(7, Is.EqualTo(report.Samples.Count));
 
         var totalNumResults = report.Samples.Aggregate(0, static (s, n) => s + n.Results.Count);
-       // Assert.Equals(21, totalNumResults);
+       Assert.That(21, Is.EqualTo(totalNumResults));
 
     }
 
@@ -55,10 +55,10 @@ public class SCIStoreDataTests
         var reportFactory = new SciStoreReportFactory(readCodeConstraint);
         var report = reportFactory.Create(data, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-       // Assert.Equals(7, report.Samples.Count);
+       Assert.That(7, Is.EqualTo(report.Samples.Count));
 
         var totalNumResults = report.Samples.Aggregate(0, static (s, n) => s + n.Results.Count);
-       // Assert.Equals(21, totalNumResults);
+       Assert.That(21, Is.EqualTo(totalNumResults));
 
         //artificially introduce duplication
         foreach (var sciStoreSample in report.Samples)
@@ -74,7 +74,7 @@ public class SCIStoreDataTests
         }
             
         var totalNumResultsAfterResolvingArtificiallyCreatedDuplication = report.Samples.Aggregate(0, static (s, n) => s + n.Results.Count);
-       // Assert.Equals(7, totalNumResultsAfterResolvingArtificiallyCreatedDuplication);
+       Assert.That(7, Is.EqualTo(totalNumResultsAfterResolvingArtificiallyCreatedDuplication));
 
 
     }

--- a/HICPluginTests/Integration/SCIStoreDataTests.cs
+++ b/HICPluginTests/Integration/SCIStoreDataTests.cs
@@ -29,10 +29,10 @@ public class SCIStoreDataTests
         var reportFactory = new SciStoreReportFactory(readCodeConstraint);
         var report = reportFactory.Create(data, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-        Assert.AreEqual(7, report.Samples.Count);
+        Assert.Equals(7, report.Samples.Count);
 
         var totalNumResults = report.Samples.Aggregate(0, static (s, n) => s + n.Results.Count);
-        Assert.AreEqual(21, totalNumResults);
+        Assert.Equals(21, totalNumResults);
 
     }
 
@@ -55,10 +55,10 @@ public class SCIStoreDataTests
         var reportFactory = new SciStoreReportFactory(readCodeConstraint);
         var report = reportFactory.Create(data, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-        Assert.AreEqual(7, report.Samples.Count);
+        Assert.Equals(7, report.Samples.Count);
 
         var totalNumResults = report.Samples.Aggregate(0, static (s, n) => s + n.Results.Count);
-        Assert.AreEqual(21, totalNumResults);
+        Assert.Equals(21, totalNumResults);
 
         //artificially introduce duplication
         foreach (var sciStoreSample in report.Samples)
@@ -74,7 +74,7 @@ public class SCIStoreDataTests
         }
             
         var totalNumResultsAfterResolvingArtificiallyCreatedDuplication = report.Samples.Aggregate(0, static (s, n) => s + n.Results.Count);
-        Assert.AreEqual(7, totalNumResultsAfterResolvingArtificiallyCreatedDuplication);
+        Assert.Equals(7, totalNumResultsAfterResolvingArtificiallyCreatedDuplication);
 
 
     }

--- a/HICPluginTests/Integration/SCIStoreDataTests.cs
+++ b/HICPluginTests/Integration/SCIStoreDataTests.cs
@@ -29,10 +29,10 @@ public class SCIStoreDataTests
         var reportFactory = new SciStoreReportFactory(readCodeConstraint);
         var report = reportFactory.Create(data, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-        Assert.Equals(7, report.Samples.Count);
+       // Assert.Equals(7, report.Samples.Count);
 
         var totalNumResults = report.Samples.Aggregate(0, static (s, n) => s + n.Results.Count);
-        Assert.Equals(21, totalNumResults);
+       // Assert.Equals(21, totalNumResults);
 
     }
 
@@ -55,10 +55,10 @@ public class SCIStoreDataTests
         var reportFactory = new SciStoreReportFactory(readCodeConstraint);
         var report = reportFactory.Create(data, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-        Assert.Equals(7, report.Samples.Count);
+       // Assert.Equals(7, report.Samples.Count);
 
         var totalNumResults = report.Samples.Aggregate(0, static (s, n) => s + n.Results.Count);
-        Assert.Equals(21, totalNumResults);
+       // Assert.Equals(21, totalNumResults);
 
         //artificially introduce duplication
         foreach (var sciStoreSample in report.Samples)
@@ -74,7 +74,7 @@ public class SCIStoreDataTests
         }
             
         var totalNumResultsAfterResolvingArtificiallyCreatedDuplication = report.Samples.Aggregate(0, static (s, n) => s + n.Results.Count);
-        Assert.Equals(7, totalNumResultsAfterResolvingArtificiallyCreatedDuplication);
+       // Assert.Equals(7, totalNumResultsAfterResolvingArtificiallyCreatedDuplication);
 
 
     }

--- a/HICPluginTests/Integration/SCIStoreWebServiceSourceTests.cs
+++ b/HICPluginTests/Integration/SCIStoreWebServiceSourceTests.cs
@@ -111,15 +111,15 @@ public class SCIStoreWebServiceSourceTests : DatabaseTests
                 return;
             }
 
-            Assert.IsNotNull(chunk);
-            Assert.AreEqual(downloadException, chunk.DownloadRequestFailedException);
+            Assert.That(chunk,Is.Not.Null);
+            Assert.Equals(downloadException, chunk.DownloadRequestFailedException);
 
             var failures = CatalogueRepository.GetAllObjects<CacheFetchFailure>();
             var numFailures = failures.Length;
-            Assert.AreEqual(1, numFailures, "The cache fetch failure was not recorded correctly.");
+            Assert.Equals(1, numFailures);//, "The cache fetch failure was not recorded correctly.");
 
             var failure = failures[0];
-            Assert.AreEqual(cacheFetchRequest.Start, failure.FetchRequestStart);
+            Assert.Equals(cacheFetchRequest.Start, failure.FetchRequestStart);
         }
         catch (Exception e)
         {

--- a/HICPluginTests/Integration/SCIStoreWebServiceSourceTests.cs
+++ b/HICPluginTests/Integration/SCIStoreWebServiceSourceTests.cs
@@ -112,14 +112,14 @@ public class SCIStoreWebServiceSourceTests : DatabaseTests
             }
 
             Assert.That(chunk,Is.Not.Null);
-            Assert.Equals(downloadException, chunk.DownloadRequestFailedException);
+           // Assert.Equals(downloadException, chunk.DownloadRequestFailedException);
 
             var failures = CatalogueRepository.GetAllObjects<CacheFetchFailure>();
             var numFailures = failures.Length;
-            Assert.Equals(1, numFailures);//, "The cache fetch failure was not recorded correctly.");
+           // Assert.Equals(1, numFailures);//, "The cache fetch failure was not recorded correctly.");
 
             var failure = failures[0];
-            Assert.Equals(cacheFetchRequest.Start, failure.FetchRequestStart);
+           // Assert.Equals(cacheFetchRequest.Start, failure.FetchRequestStart);
         }
         catch (Exception e)
         {

--- a/HICPluginTests/Integration/SCIStoreWebServiceSourceTests.cs
+++ b/HICPluginTests/Integration/SCIStoreWebServiceSourceTests.cs
@@ -112,14 +112,14 @@ public class SCIStoreWebServiceSourceTests : DatabaseTests
             }
 
             Assert.That(chunk,Is.Not.Null);
-           // Assert.Equals(downloadException, chunk.DownloadRequestFailedException);
+           Assert.That(downloadException, Is.EqualTo(chunk.DownloadRequestFailedException));
 
             var failures = CatalogueRepository.GetAllObjects<CacheFetchFailure>();
             var numFailures = failures.Length;
-           // Assert.Equals(1, numFailures);//, "The cache fetch failure was not recorded correctly.");
+           Assert.That(1, Is.EqualTo(numFailures));//, "The cache fetch failure was not recorded correctly.");
 
             var failure = failures[0];
-           // Assert.Equals(cacheFetchRequest.Start, failure.FetchRequestStart);
+           Assert.That(cacheFetchRequest.Start, Is.EqualTo(failure.FetchRequestStart));
         }
         catch (Exception e)
         {

--- a/HICPluginTests/PackageListIsCorrectTests.cs
+++ b/HICPluginTests/PackageListIsCorrectTests.cs
@@ -54,7 +54,6 @@ public class PackageListIsCorrectTests
 
         var unusedPackages = packagesMarkdown.Except(usedPackages).ToArray();
         Assert.That(unusedPackages, Is.Empty);
-            // $"The following packages are listed in PACKAGES.md but are not used in any csproj file: {string.Join(", ", unusedPackages)}");
         Assert.That(undocumented.ToString(), Is.Empty);
     }
 
@@ -81,7 +80,7 @@ public class PackageListIsCorrectTests
         var root = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
         while (!root.EnumerateFiles("*.sln", SearchOption.TopDirectoryOnly).Any() && root.Parent != null)
             root = root.Parent;
-        Assert.That(root.Parent, Is.Not.Null);//"Could not find root of repository");
+        Assert.That(root.Parent, Is.Not.Null);
         return root;
     }
 
@@ -103,7 +102,7 @@ public class PackageListIsCorrectTests
     private static string[] GetPackagesMarkdown(DirectoryInfo root)
     {
         var path = root.EnumerateFiles("packages.md", EnumerationOptions).Select(f => f.FullName).ToArray();
-        Assert.That(path.Length==0, Is.False);// "Could not find packages.md");
+        Assert.That(path.Length==0, Is.False);
         return path;
     }
 

--- a/HICPluginTests/PackageListIsCorrectTests.cs
+++ b/HICPluginTests/PackageListIsCorrectTests.cs
@@ -53,9 +53,9 @@ public class PackageListIsCorrectTests
         undocumented.AppendJoin(Environment.NewLine, undocumentedPackages);
 
         var unusedPackages = packagesMarkdown.Except(usedPackages).ToArray();
-        Assert.IsEmpty(unusedPackages,
-            $"The following packages are listed in PACKAGES.md but are not used in any csproj file: {string.Join(", ", unusedPackages)}");
-        Assert.IsEmpty(undocumented.ToString());
+        Assert.That(unusedPackages, Is.Empty);
+            // $"The following packages are listed in PACKAGES.md but are not used in any csproj file: {string.Join(", ", unusedPackages)}");
+        Assert.That(undocumented.ToString(), Is.Empty);
     }
 
     /// <summary>
@@ -81,7 +81,7 @@ public class PackageListIsCorrectTests
         var root = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
         while (!root.EnumerateFiles("*.sln", SearchOption.TopDirectoryOnly).Any() && root.Parent != null)
             root = root.Parent;
-        Assert.IsNotNull(root.Parent, "Could not find root of repository");
+        Assert.That(root.Parent, Is.Not.Null);//"Could not find root of repository");
         return root;
     }
 
@@ -103,7 +103,7 @@ public class PackageListIsCorrectTests
     private static string[] GetPackagesMarkdown(DirectoryInfo root)
     {
         var path = root.EnumerateFiles("packages.md", EnumerationOptions).Select(f => f.FullName).ToArray();
-        Assert.False(path.Length==0, "Could not find packages.md");
+        Assert.That(path.Length==0, Is.False);// "Could not find packages.md");
         return path;
     }
 

--- a/HICPluginTests/SourceArchiveTests.cs
+++ b/HICPluginTests/SourceArchiveTests.cs
@@ -28,14 +28,14 @@ public class SourceArchiveTests
             var archiveProvider = new FilesystemArchiveProvider(rootDirPath, new[] {".txt"}, ThrowImmediatelyDataLoadEventListener.Quiet);
             var entryNames = archiveProvider.EntryNames.ToList();
 
-            Assert.IsTrue(entryNames.Contains("file1.txt"));
-            Assert.IsTrue(entryNames.Contains("file2.txt"));
-            Assert.IsTrue(entryNames.Contains("file3.txt"));
-            Assert.IsFalse(entryNames.Contains("not-part-of-archive.foo"));
+            Assert.That(entryNames.Contains("file1.txt"), Is.True);
+            Assert.That(entryNames.Contains("file2.txt"), Is.True);
+            Assert.That(entryNames.Contains("file3.txt"), Is.True);
+            Assert.That(entryNames.Contains("not-part-of-archive.foo"), Is.False);
 
             using var file1 = archiveProvider.EntryStreams.Single(kvp => kvp.Key == "file1.txt").Value;
             using var reader = new StreamReader(file1);
-            Assert.AreEqual("test", reader.ReadLine());
+            Assert.Equals("test", reader.ReadLine());
         }
         finally
         {

--- a/HICPluginTests/SourceArchiveTests.cs
+++ b/HICPluginTests/SourceArchiveTests.cs
@@ -35,7 +35,7 @@ public class SourceArchiveTests
 
             using var file1 = archiveProvider.EntryStreams.Single(kvp => kvp.Key == "file1.txt").Value;
             using var reader = new StreamReader(file1);
-           // Assert.Equals("test", reader.ReadLine());
+           Assert.That("test", Is.EqualTo(reader.ReadLine()));
         }
         finally
         {

--- a/HICPluginTests/SourceArchiveTests.cs
+++ b/HICPluginTests/SourceArchiveTests.cs
@@ -35,7 +35,7 @@ public class SourceArchiveTests
 
             using var file1 = archiveProvider.EntryStreams.Single(kvp => kvp.Key == "file1.txt").Value;
             using var reader = new StreamReader(file1);
-            Assert.Equals("test", reader.ReadLine());
+           // Assert.Equals("test", reader.ReadLine());
         }
         finally
         {

--- a/HICPluginTests/Unit/CHIColumnFinderTests.cs
+++ b/HICPluginTests/Unit/CHIColumnFinderTests.cs
@@ -49,7 +49,6 @@ public class CHIColumnFinderTests : TestsRequiringAnExtractionConfiguration
 
     [TestCase("1111111111 101010109", true)] //valid 10 digit and valid 9 digit with whitespace between
     [TestCase("1111111115 1111111111 101010108 111111110", true)] //invalid 10 digit, valid 10 digit, invalid 9 digit, valid 9 digit, all separated by whitespace
-    [TestCase("", false)] //invalid 10 digit, valid 10 digit, invalid 9 digit, valid 9 digit, all separated by whitespace
     public void TestDataWithCHIs(string toCheck, bool expectedToBeChi)
     {
         using var toProcess = new DataTable();
@@ -65,7 +64,7 @@ public class CHIColumnFinderTests : TestsRequiringAnExtractionConfiguration
             Assert.DoesNotThrow(() => _chiFinder.ProcessPipelineData(toProcess, _listener, null));
             var lines = File.ReadAllLines(_request.GetExtractionDirectory().FullName + "/FoundCHIs/_potential_CHI_Locations.csv");
             Assert.That(lines.Length, Is.EqualTo(2));
-            //Assert.That(lines[1].Contains($",{toCheck}"), Is.True);
+            Assert.That(lines[1].Contains($",{toCheck}"), Is.True);
         }
         else
             Assert.DoesNotThrow(() => _chiFinder.ProcessPipelineData(toProcess, _listener, null));

--- a/HICPluginTests/Unit/CHIColumnFinderTests.cs
+++ b/HICPluginTests/Unit/CHIColumnFinderTests.cs
@@ -92,6 +92,6 @@ public class CHIColumnFinderTests
         Assert.DoesNotThrow(() => cf.ProcessPipelineData(toProcess, _listener, null));
         var result = Directory.GetFiles(TestContext.CurrentContext.WorkDirectory, "*.csv", SearchOption.AllDirectories)
             .First(static name => name.EndsWith("_Potential_CHI_Locations.csv", StringComparison.Ordinal));
-        Assert.Equals(File.ReadLines(result).ToList().Contains("CHI,1111111111,1111111111"),true);
+       // Assert.Equals(File.ReadLines(result).ToList().Contains("CHI,1111111111,1111111111"),true);
     }
 }

--- a/HICPluginTests/Unit/CHIColumnFinderTests.cs
+++ b/HICPluginTests/Unit/CHIColumnFinderTests.cs
@@ -92,6 +92,6 @@ public class CHIColumnFinderTests
         Assert.DoesNotThrow(() => cf.ProcessPipelineData(toProcess, _listener, null));
         var result = Directory.GetFiles(TestContext.CurrentContext.WorkDirectory, "*.csv", SearchOption.AllDirectories)
             .First(static name => name.EndsWith("_Potential_CHI_Locations.csv", StringComparison.Ordinal));
-       // Assert.Equals(File.ReadLines(result).ToList().Contains("CHI,1111111111,1111111111"),true);
+       Assert.That(File.ReadLines(result).ToList().Contains("CHI,1111111111,1111111111"),Is.EqualTo(true));
     }
 }

--- a/HICPluginTests/Unit/CHIColumnFinderTests.cs
+++ b/HICPluginTests/Unit/CHIColumnFinderTests.cs
@@ -92,6 +92,6 @@ public class CHIColumnFinderTests
         Assert.DoesNotThrow(() => cf.ProcessPipelineData(toProcess, _listener, null));
         var result = Directory.GetFiles(TestContext.CurrentContext.WorkDirectory, "*.csv", SearchOption.AllDirectories)
             .First(static name => name.EndsWith("_Potential_CHI_Locations.csv", StringComparison.Ordinal));
-        Assert.Contains("CHI,1111111111,1111111111",File.ReadLines(result).ToList());
+        Assert.Equals(File.ReadLines(result).ToList().Contains("CHI,1111111111,1111111111"),true);
     }
 }

--- a/HICPluginTests/Unit/CHIColumnFinderTests.cs
+++ b/HICPluginTests/Unit/CHIColumnFinderTests.cs
@@ -62,13 +62,13 @@ public class CHIColumnFinderTests : TestsRequiringAnExtractionConfiguration
         if (expectedToBeChi)
         {
             Assert.DoesNotThrow(() => _chiFinder.ProcessPipelineData(toProcess, _listener, null));
-            var lines = File.ReadAllLines(_request.GetExtractionDirectory().Parent.Parent.FullName + "/FoundCHIs/_potential_CHI_Locations.csv");
+            var lines = File.ReadAllLines(_request.GetExtractionDirectory().Parent.Parent.FullName + $"/FoundCHIs/{_request.GetExtractionDirectory().Parent.Name}__potential_CHI_Locations.csv");
             Assert.That(lines.Length, Is.EqualTo(2));
             Assert.That(lines[1].Contains($",{toCheck}"), Is.True);
+            File.Delete(_request.GetExtractionDirectory().Parent.Parent.FullName + $"/FoundCHIs/{_request.GetExtractionDirectory().Parent.Name}__potential_CHI_Locations.csv");
         }
         else
             Assert.DoesNotThrow(() => _chiFinder.ProcessPipelineData(toProcess, _listener, null));
-        File.Delete(_request.GetExtractionDirectory().Parent.Parent.FullName + "/FoundCHIs/_potential_CHI_Locations.csv");
 
     }
 

--- a/HICPluginTests/Unit/CHIColumnFinderTests.cs
+++ b/HICPluginTests/Unit/CHIColumnFinderTests.cs
@@ -62,12 +62,14 @@ public class CHIColumnFinderTests : TestsRequiringAnExtractionConfiguration
         if (expectedToBeChi)
         {
             Assert.DoesNotThrow(() => _chiFinder.ProcessPipelineData(toProcess, _listener, null));
-            var lines = File.ReadAllLines(_request.GetExtractionDirectory().FullName + "/FoundCHIs/_potential_CHI_Locations.csv");
+            var lines = File.ReadAllLines(_request.GetExtractionDirectory().Parent.Parent.FullName + "/FoundCHIs/_potential_CHI_Locations.csv");
             Assert.That(lines.Length, Is.EqualTo(2));
             Assert.That(lines[1].Contains($",{toCheck}"), Is.True);
         }
         else
             Assert.DoesNotThrow(() => _chiFinder.ProcessPipelineData(toProcess, _listener, null));
+        File.Delete(_request.GetExtractionDirectory().Parent.Parent.FullName + "/FoundCHIs/_potential_CHI_Locations.csv");
+
     }
 
     [Test]

--- a/HICPluginTests/Unit/CHIMutilatorTests.cs
+++ b/HICPluginTests/Unit/CHIMutilatorTests.cs
@@ -18,6 +18,6 @@ class CHIMutilatorTests:UnitTests
 
         //property defaults to true
         var addZero = pt.ProcessTaskArguments.Single(static a => a.Name.Equals("TryAddingZeroToFront"));
-       // Assert.Equals(true,addZero.GetValueAsSystemType());
+        Assert.That(true,Is.EqualTo(addZero.GetValueAsSystemType()));
     }
 }

--- a/HICPluginTests/Unit/CHIMutilatorTests.cs
+++ b/HICPluginTests/Unit/CHIMutilatorTests.cs
@@ -18,6 +18,6 @@ class CHIMutilatorTests:UnitTests
 
         //property defaults to true
         var addZero = pt.ProcessTaskArguments.Single(static a => a.Name.Equals("TryAddingZeroToFront"));
-        Assert.AreEqual(true,addZero.GetValueAsSystemType());
+        Assert.Equals(true,addZero.GetValueAsSystemType());
     }
 }

--- a/HICPluginTests/Unit/CHIMutilatorTests.cs
+++ b/HICPluginTests/Unit/CHIMutilatorTests.cs
@@ -18,6 +18,6 @@ class CHIMutilatorTests:UnitTests
 
         //property defaults to true
         var addZero = pt.ProcessTaskArguments.Single(static a => a.Name.Equals("TryAddingZeroToFront"));
-        Assert.Equals(true,addZero.GetValueAsSystemType());
+       // Assert.Equals(true,addZero.GetValueAsSystemType());
     }
 }

--- a/HICPluginTests/Unit/CodeValidationTests.cs
+++ b/HICPluginTests/Unit/CodeValidationTests.cs
@@ -48,7 +48,7 @@ public class CodeValidationTests : DatabaseTests
         var testSetFactory = new TestSetFactory(readCodeConstraint);
         var testDetails = testSetFactory.CreateFromTestType(testType, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-       // Assert.Equals("NOT_A_READ_CODE", testDetails.LocalCode.Value);
+       Assert.That("NOT_A_READ_CODE", Is.EqualTo(testDetails.LocalCode.Value));
         Assert.That(testDetails.ReadCode, Is.Null);
     }
 
@@ -84,7 +84,7 @@ public class CodeValidationTests : DatabaseTests
         var testDetails = testSetFactory.CreateFromTestType(testType, ThrowImmediatelyDataLoadEventListener.Quiet);
 
         Assert.That(testDetails.ReadCode, Is.Not.Null);// "The value has not been picked up as a read code");
-       // Assert.Equals(".0766", testDetails.ReadCode.Value);
+       Assert.That(".0766", Is.EqualTo(testDetails.ReadCode.Value));
         Assert.That(testDetails.LocalCode, Is.Null);
     }
 
@@ -137,7 +137,7 @@ public class CodeValidationTests : DatabaseTests
         Assert.That(testDetails.ReadCode,Is.Not.Null);
         Assert.That(testDetails.LocalCode,Is.Not.Null);
 
-       // Assert.Equals("4Q24.", testDetails.ReadCode.Value);
-       // Assert.Equals("GGOC", testDetails.LocalCode.Value);
+       Assert.That("4Q24.", Is.EqualTo(testDetails.ReadCode.Value));
+       Assert.That("GGOC",Is.EqualTo( testDetails.LocalCode.Value));
     }
 }

--- a/HICPluginTests/Unit/CodeValidationTests.cs
+++ b/HICPluginTests/Unit/CodeValidationTests.cs
@@ -83,7 +83,7 @@ public class CodeValidationTests : DatabaseTests
         var testSetFactory = new TestSetFactory(readCodeConstraint);
         var testDetails = testSetFactory.CreateFromTestType(testType, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-        Assert.That(testDetails.ReadCode, Is.Not.Null);// "The value has not been picked up as a read code");
+        Assert.That(testDetails.ReadCode, Is.Not.Null);
        Assert.That(".0766", Is.EqualTo(testDetails.ReadCode.Value));
         Assert.That(testDetails.LocalCode, Is.Null);
     }

--- a/HICPluginTests/Unit/CodeValidationTests.cs
+++ b/HICPluginTests/Unit/CodeValidationTests.cs
@@ -48,8 +48,8 @@ public class CodeValidationTests : DatabaseTests
         var testSetFactory = new TestSetFactory(readCodeConstraint);
         var testDetails = testSetFactory.CreateFromTestType(testType, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-        Assert.AreEqual("NOT_A_READ_CODE", testDetails.LocalCode.Value);
-        Assert.IsNull(testDetails.ReadCode);
+        Assert.Equals("NOT_A_READ_CODE", testDetails.LocalCode.Value);
+        Assert.That(testDetails.ReadCode, Is.Null);
     }
 
     [Test]
@@ -83,9 +83,9 @@ public class CodeValidationTests : DatabaseTests
         var testSetFactory = new TestSetFactory(readCodeConstraint);
         var testDetails = testSetFactory.CreateFromTestType(testType, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-        Assert.IsNotNull(testDetails.ReadCode, "The value has not been picked up as a read code");
-        Assert.AreEqual(".0766", testDetails.ReadCode.Value);
-        Assert.IsNull(testDetails.LocalCode);
+        Assert.That(testDetails.ReadCode, Is.Not.Null);// "The value has not been picked up as a read code");
+        Assert.Equals(".0766", testDetails.ReadCode.Value);
+        Assert.That(testDetails.LocalCode, Is.Null);
     }
 
     [Test]
@@ -134,10 +134,10 @@ public class CodeValidationTests : DatabaseTests
         var testSetFactory = new TestSetFactory(readCodeConstraint);
         var testDetails = testSetFactory.CreateFromTestType(testType, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-        Assert.IsNotNull(testDetails.ReadCode);
-        Assert.IsNotNull(testDetails.LocalCode);
+        Assert.That(testDetails.ReadCode,Is.Not.Null);
+        Assert.That(testDetails.LocalCode,Is.Not.Null);
 
-        Assert.AreEqual("4Q24.", testDetails.ReadCode.Value);
-        Assert.AreEqual("GGOC", testDetails.LocalCode.Value);
+        Assert.Equals("4Q24.", testDetails.ReadCode.Value);
+        Assert.Equals("GGOC", testDetails.LocalCode.Value);
     }
 }

--- a/HICPluginTests/Unit/CodeValidationTests.cs
+++ b/HICPluginTests/Unit/CodeValidationTests.cs
@@ -48,7 +48,7 @@ public class CodeValidationTests : DatabaseTests
         var testSetFactory = new TestSetFactory(readCodeConstraint);
         var testDetails = testSetFactory.CreateFromTestType(testType, ThrowImmediatelyDataLoadEventListener.Quiet);
 
-        Assert.Equals("NOT_A_READ_CODE", testDetails.LocalCode.Value);
+       // Assert.Equals("NOT_A_READ_CODE", testDetails.LocalCode.Value);
         Assert.That(testDetails.ReadCode, Is.Null);
     }
 
@@ -84,7 +84,7 @@ public class CodeValidationTests : DatabaseTests
         var testDetails = testSetFactory.CreateFromTestType(testType, ThrowImmediatelyDataLoadEventListener.Quiet);
 
         Assert.That(testDetails.ReadCode, Is.Not.Null);// "The value has not been picked up as a read code");
-        Assert.Equals(".0766", testDetails.ReadCode.Value);
+       // Assert.Equals(".0766", testDetails.ReadCode.Value);
         Assert.That(testDetails.LocalCode, Is.Null);
     }
 
@@ -137,7 +137,7 @@ public class CodeValidationTests : DatabaseTests
         Assert.That(testDetails.ReadCode,Is.Not.Null);
         Assert.That(testDetails.LocalCode,Is.Not.Null);
 
-        Assert.Equals("4Q24.", testDetails.ReadCode.Value);
-        Assert.Equals("GGOC", testDetails.LocalCode.Value);
+       // Assert.Equals("4Q24.", testDetails.ReadCode.Value);
+       // Assert.Equals("GGOC", testDetails.LocalCode.Value);
     }
 }

--- a/HICPluginTests/Unit/ContextTests.cs
+++ b/HICPluginTests/Unit/ContextTests.cs
@@ -33,6 +33,6 @@ public class ContextTests : DatabaseTests
         var cacheContext = (DataFlowPipelineContext<ICacheChunk>)useCase.GetContext();
 
         //we shouldn't be able to have data export sources in this context
-        Assert.IsTrue(cacheContext.IsAllowable(typeof(SCIStoreWebServiceSource)));
+        Assert.That(cacheContext.IsAllowable(typeof(SCIStoreWebServiceSource)), Is.True);
     }
 }

--- a/HICPluginTests/Unit/LimitedRetryThenContinueStrategyTests.cs
+++ b/HICPluginTests/Unit/LimitedRetryThenContinueStrategyTests.cs
@@ -19,11 +19,11 @@ public class LimitedRetryThenContinueStrategyTests
         var strategy = new LimitedRetryThenContinueStrategy(5,new List<int>(new int[]{3,1}), mockServer);
 
             
-       // Assert.Equals(4,strategy.RetryAfterCooldown(new TimeSpan(1,0,0,0), ThrowImmediatelyDataLoadEventListener.Quiet, 5, new Exception()));
-       // Assert.Equals(3, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 4, new Exception()));
-       // Assert.Equals(2, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 3, new Exception()));
-       // Assert.Equals(1, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 2, new Exception()));
-       // Assert.Equals(0, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 1, new Exception()));
+       Assert.That(4,Is.EqualTo(strategy.RetryAfterCooldown(new TimeSpan(1,0,0,0), ThrowImmediatelyDataLoadEventListener.Quiet, 5, new Exception())));
+       Assert.That(3, Is.EqualTo(strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 4, new Exception())));
+       Assert.That(2, Is.EqualTo(strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 3, new Exception())));
+       Assert.That(1, Is.EqualTo(strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 2, new Exception())));
+       Assert.That(0, Is.EqualTo(strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 1, new Exception())));
 
     }
 }

--- a/HICPluginTests/Unit/LimitedRetryThenContinueStrategyTests.cs
+++ b/HICPluginTests/Unit/LimitedRetryThenContinueStrategyTests.cs
@@ -19,11 +19,11 @@ public class LimitedRetryThenContinueStrategyTests
         var strategy = new LimitedRetryThenContinueStrategy(5,new List<int>(new int[]{3,1}), mockServer);
 
             
-        Assert.AreEqual(4,strategy.RetryAfterCooldown(new TimeSpan(1,0,0,0), ThrowImmediatelyDataLoadEventListener.Quiet, 5, new Exception()));
-        Assert.AreEqual(3, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 4, new Exception()));
-        Assert.AreEqual(2, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 3, new Exception()));
-        Assert.AreEqual(1, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 2, new Exception()));
-        Assert.AreEqual(0, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 1, new Exception()));
+        Assert.Equals(4,strategy.RetryAfterCooldown(new TimeSpan(1,0,0,0), ThrowImmediatelyDataLoadEventListener.Quiet, 5, new Exception()));
+        Assert.Equals(3, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 4, new Exception()));
+        Assert.Equals(2, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 3, new Exception()));
+        Assert.Equals(1, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 2, new Exception()));
+        Assert.Equals(0, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 1, new Exception()));
 
     }
 }

--- a/HICPluginTests/Unit/LimitedRetryThenContinueStrategyTests.cs
+++ b/HICPluginTests/Unit/LimitedRetryThenContinueStrategyTests.cs
@@ -19,11 +19,11 @@ public class LimitedRetryThenContinueStrategyTests
         var strategy = new LimitedRetryThenContinueStrategy(5,new List<int>(new int[]{3,1}), mockServer);
 
             
-        Assert.Equals(4,strategy.RetryAfterCooldown(new TimeSpan(1,0,0,0), ThrowImmediatelyDataLoadEventListener.Quiet, 5, new Exception()));
-        Assert.Equals(3, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 4, new Exception()));
-        Assert.Equals(2, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 3, new Exception()));
-        Assert.Equals(1, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 2, new Exception()));
-        Assert.Equals(0, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 1, new Exception()));
+       // Assert.Equals(4,strategy.RetryAfterCooldown(new TimeSpan(1,0,0,0), ThrowImmediatelyDataLoadEventListener.Quiet, 5, new Exception()));
+       // Assert.Equals(3, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 4, new Exception()));
+       // Assert.Equals(2, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 3, new Exception()));
+       // Assert.Equals(1, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 2, new Exception()));
+       // Assert.Equals(0, strategy.RetryAfterCooldown(new TimeSpan(1, 0, 0, 0), ThrowImmediatelyDataLoadEventListener.Quiet, 1, new Exception()));
 
     }
 }

--- a/HICPluginTests/Unit/MicrobiologyLoaderTests.cs
+++ b/HICPluginTests/Unit/MicrobiologyLoaderTests.cs
@@ -36,7 +36,7 @@ public class MicrobiologyLoaderTests
         var result1 = MicroBiologyFileReader.GetSpecimenNo(tr);
 
         //result is not null if it is a valid result code
-        Assert.IsTrue(isValidResultCode == (result1 != null));
+        Assert.That(isValidResultCode == (result1 != null),Is.True);
     }
 
     [Test]
@@ -222,11 +222,11 @@ GORA1H
         var results = CreateReaderFromString(testString, true);
 
 
-        Assert.AreEqual(5, results.Count(r => r is MB_Lab));
-        Assert.AreEqual(5, results.Where(r => r is MB_Tests).Cast<MB_Tests>().Count(t=>t.TestCode.Equals("VTK")));
+        Assert.Equals(5, results.Count(r => r is MB_Lab));
+        Assert.Equals(5, results.Where(r => r is MB_Tests).Cast<MB_Tests>().Count(t=>t.TestCode.Equals("VTK")));
 
-        Assert.AreEqual(35, results.Count(r => r is MB_IsolationResult));
-        Assert.AreEqual(2, results.Count(r => r is MB_Isolation));
+        Assert.Equals(35, results.Count(r => r is MB_IsolationResult));
+        Assert.Equals(2, results.Count(r => r is MB_Isolation));
 
 
     }
@@ -287,23 +287,23 @@ MB
 THOK1H
 ";
         var results = CreateReaderFromString(testString, true);
-        Assert.AreEqual(6,results.Count);
+        Assert.Equals(6,results.Count);
 
         var isolations = results.Where(r => r is MB_Isolation).Cast<MB_Isolation>().ToArray();
-        Assert.AreEqual(2, isolations.Length);
+        Assert.Equals(2, isolations.Length);
 
 
-        Assert.AreEqual(0, results.Count(r => r is MB_IsolationResult));//should be no results because there are no "$SENS             S" etc bits
+        Assert.Equals(0, results.Count(r => r is MB_IsolationResult));//should be no results because there are no "$SENS             S" etc bits
 
-        Assert.AreEqual("SAUR",isolations[0].organismCode );
-        Assert.AreEqual("P", isolations[0].WeightGrowth_cd);
-        Assert.AreEqual("Y",isolations[0].IntCode1);
-        Assert.AreEqual("Y",isolations[0].IntCode2);
+        Assert.Equals("SAUR",isolations[0].organismCode );
+        Assert.Equals("P", isolations[0].WeightGrowth_cd);
+        Assert.Equals("Y",isolations[0].IntCode1);
+        Assert.Equals("Y",isolations[0].IntCode2);
 
-        Assert.AreEqual("BOBY",isolations[1].organismCode);
-        Assert.AreEqual("Z",isolations[1].WeightGrowth_cd);
-        Assert.AreEqual("N",isolations[1].IntCode1);
-        Assert.AreEqual("N",isolations[1].IntCode2);
+        Assert.Equals("BOBY",isolations[1].organismCode);
+        Assert.Equals("Z",isolations[1].WeightGrowth_cd);
+        Assert.Equals("N",isolations[1].IntCode1);
+        Assert.Equals("N",isolations[1].IntCode2);
 
 
 
@@ -332,8 +332,8 @@ MB
 NG
 ";
         var results = CreateReaderFromString(testString, true);
-        Assert.AreEqual(3, results.Count);
-        Assert.AreEqual("LIKELY APPENDICITIS|PERSISTENT FEVER & SIRS|ON AMOX- GENT- METRO|###SENT IN WITHOUT FORM OR ICE REQUEST. DETAILS ON A HISTORY/CONTINUATION SHEET NP 11/11/11", ((MB_Lab)results.Single(r => r is MB_Lab)).Comments);
+        Assert.Equals(3, results.Count);
+        Assert.Equals("LIKELY APPENDICITIS|PERSISTENT FEVER & SIRS|ON AMOX- GENT- METRO|###SENT IN WITHOUT FORM OR ICE REQUEST. DETAILS ON A HISTORY/CONTINUATION SHEET NP 11/11/11", ((MB_Lab)results.Single(r => r is MB_Lab)).Comments);
 
     }
 
@@ -377,7 +377,7 @@ MB
 LOVG1H
 ";
         var results = CreateReaderFromString(testString, true);
-        Assert.AreEqual(11, results.Count);
+        Assert.Equals(11, results.Count);
     }
 
     [Test]
@@ -425,9 +425,9 @@ The following record ids do not exist:
 
 ";
         var results = CreateReaderFromString(testString, true);
-        Assert.AreEqual(11, results.Count);
-        Assert.AreEqual("11:11",((MB_Lab)results.Single(r=>r is MB_Lab)).RcvTime);
-        Assert.AreEqual("11:11", ((MB_Lab)results.Single(r => r is MB_Lab)).SampleTime);
+        Assert.Equals(11, results.Count);
+        Assert.Equals("11:11",((MB_Lab)results.Single(r=>r is MB_Lab)).RcvTime);
+        Assert.Equals("11:11", ((MB_Lab)results.Single(r => r is MB_Lab)).SampleTime);
     }
 
     [Test]
@@ -472,7 +472,7 @@ MB
 DYMT1G
 ";
         var results = CreateReaderFromString(testString, false);
-        Assert.AreEqual(4,results.Count);
+        Assert.Equals(4,results.Count);
     }
 
     [Test]
@@ -614,7 +614,7 @@ MB
 JOSJ1H
 ";
         var results = CreateReaderFromString(testString, false);
-        Assert.AreEqual(90, results.Count);
+        Assert.Equals(90, results.Count);
 
     }
 
@@ -635,7 +635,7 @@ ANDERSON
 ";
 
         var ex = Assert.Throws<Exception>(()=>CreateReaderFromString(testString, true));
-        StringAssert.Contains("Warning was End of file reached halfway through an MB_Lab record population",ex.Message);
+        Assert.That(ex.Message.Contains("Warning was End of file reached halfway through an MB_Lab record population"),Is.True);
 
 
     }
@@ -689,12 +689,12 @@ MP
 SHEA1H";
         var results = CreateReaderFromString(testString, true);
 
-        Assert.AreEqual(12,results.Count(r => r is MB_IsolationResult));
+        Assert.Equals(12,results.Count(r => r is MB_IsolationResult));
 
         var t = ((MB_Tests) results.FirstOrDefault(r => r is MB_Tests));
 
-        Assert.NotNull(t);
-        Assert.AreEqual("BLAN", t.TestCode);
+        Assert.That(t, Is.Not.Null);
+        Assert.Equals("BLAN", t.TestCode);
 
     }
 }

--- a/HICPluginTests/Unit/MicrobiologyLoaderTests.cs
+++ b/HICPluginTests/Unit/MicrobiologyLoaderTests.cs
@@ -222,11 +222,11 @@ GORA1H
         var results = CreateReaderFromString(testString, true);
 
 
-        Assert.Equals(5, results.Count(r => r is MB_Lab));
-        Assert.Equals(5, results.Where(r => r is MB_Tests).Cast<MB_Tests>().Count(t=>t.TestCode.Equals("VTK")));
+       // Assert.Equals(5, results.Count(r => r is MB_Lab));
+       // Assert.Equals(5, results.Where(r => r is MB_Tests).Cast<MB_Tests>().Count(t=>t.TestCode.Equals("VTK")));
 
-        Assert.Equals(35, results.Count(r => r is MB_IsolationResult));
-        Assert.Equals(2, results.Count(r => r is MB_Isolation));
+       // Assert.Equals(35, results.Count(r => r is MB_IsolationResult));
+       // Assert.Equals(2, results.Count(r => r is MB_Isolation));
 
 
     }
@@ -287,23 +287,23 @@ MB
 THOK1H
 ";
         var results = CreateReaderFromString(testString, true);
-        Assert.Equals(6,results.Count);
+       // Assert.Equals(6,results.Count);
 
         var isolations = results.Where(r => r is MB_Isolation).Cast<MB_Isolation>().ToArray();
-        Assert.Equals(2, isolations.Length);
+       // Assert.Equals(2, isolations.Length);
 
 
-        Assert.Equals(0, results.Count(r => r is MB_IsolationResult));//should be no results because there are no "$SENS             S" etc bits
+       // Assert.Equals(0, results.Count(r => r is MB_IsolationResult));//should be no results because there are no "$SENS             S" etc bits
 
-        Assert.Equals("SAUR",isolations[0].organismCode );
-        Assert.Equals("P", isolations[0].WeightGrowth_cd);
-        Assert.Equals("Y",isolations[0].IntCode1);
-        Assert.Equals("Y",isolations[0].IntCode2);
+       // Assert.Equals("SAUR",isolations[0].organismCode );
+       // Assert.Equals("P", isolations[0].WeightGrowth_cd);
+       // Assert.Equals("Y",isolations[0].IntCode1);
+       // Assert.Equals("Y",isolations[0].IntCode2);
 
-        Assert.Equals("BOBY",isolations[1].organismCode);
-        Assert.Equals("Z",isolations[1].WeightGrowth_cd);
-        Assert.Equals("N",isolations[1].IntCode1);
-        Assert.Equals("N",isolations[1].IntCode2);
+       // Assert.Equals("BOBY",isolations[1].organismCode);
+       // Assert.Equals("Z",isolations[1].WeightGrowth_cd);
+       // Assert.Equals("N",isolations[1].IntCode1);
+       // Assert.Equals("N",isolations[1].IntCode2);
 
 
 
@@ -332,8 +332,8 @@ MB
 NG
 ";
         var results = CreateReaderFromString(testString, true);
-        Assert.Equals(3, results.Count);
-        Assert.Equals("LIKELY APPENDICITIS|PERSISTENT FEVER & SIRS|ON AMOX- GENT- METRO|###SENT IN WITHOUT FORM OR ICE REQUEST. DETAILS ON A HISTORY/CONTINUATION SHEET NP 11/11/11", ((MB_Lab)results.Single(r => r is MB_Lab)).Comments);
+       // Assert.Equals(3, results.Count);
+       // Assert.Equals("LIKELY APPENDICITIS|PERSISTENT FEVER & SIRS|ON AMOX- GENT- METRO|###SENT IN WITHOUT FORM OR ICE REQUEST. DETAILS ON A HISTORY/CONTINUATION SHEET NP 11/11/11", ((MB_Lab)results.Single(r => r is MB_Lab)).Comments);
 
     }
 
@@ -377,7 +377,7 @@ MB
 LOVG1H
 ";
         var results = CreateReaderFromString(testString, true);
-        Assert.Equals(11, results.Count);
+       // Assert.Equals(11, results.Count);
     }
 
     [Test]
@@ -425,9 +425,9 @@ The following record ids do not exist:
 
 ";
         var results = CreateReaderFromString(testString, true);
-        Assert.Equals(11, results.Count);
-        Assert.Equals("11:11",((MB_Lab)results.Single(r=>r is MB_Lab)).RcvTime);
-        Assert.Equals("11:11", ((MB_Lab)results.Single(r => r is MB_Lab)).SampleTime);
+       // Assert.Equals(11, results.Count);
+       // Assert.Equals("11:11",((MB_Lab)results.Single(r=>r is MB_Lab)).RcvTime);
+       // Assert.Equals("11:11", ((MB_Lab)results.Single(r => r is MB_Lab)).SampleTime);
     }
 
     [Test]
@@ -472,7 +472,7 @@ MB
 DYMT1G
 ";
         var results = CreateReaderFromString(testString, false);
-        Assert.Equals(4,results.Count);
+       // Assert.Equals(4,results.Count);
     }
 
     [Test]
@@ -614,7 +614,7 @@ MB
 JOSJ1H
 ";
         var results = CreateReaderFromString(testString, false);
-        Assert.Equals(90, results.Count);
+       // Assert.Equals(90, results.Count);
 
     }
 
@@ -689,12 +689,12 @@ MP
 SHEA1H";
         var results = CreateReaderFromString(testString, true);
 
-        Assert.Equals(12,results.Count(r => r is MB_IsolationResult));
+       // Assert.Equals(12,results.Count(r => r is MB_IsolationResult));
 
         var t = ((MB_Tests) results.FirstOrDefault(r => r is MB_Tests));
 
         Assert.That(t, Is.Not.Null);
-        Assert.Equals("BLAN", t.TestCode);
+       // Assert.Equals("BLAN", t.TestCode);
 
     }
 }

--- a/HICPluginTests/Unit/MicrobiologyLoaderTests.cs
+++ b/HICPluginTests/Unit/MicrobiologyLoaderTests.cs
@@ -222,11 +222,11 @@ GORA1H
         var results = CreateReaderFromString(testString, true);
 
 
-       // Assert.Equals(5, results.Count(r => r is MB_Lab));
-       // Assert.Equals(5, results.Where(r => r is MB_Tests).Cast<MB_Tests>().Count(t=>t.TestCode.Equals("VTK")));
+       Assert.That(5, Is.EqualTo(results.Count(r => r is MB_Lab)));
+       Assert.That(5, Is.EqualTo(results.Where(r => r is MB_Tests).Cast<MB_Tests>().Count(t=>t.TestCode.Equals("VTK"))));
 
-       // Assert.Equals(35, results.Count(r => r is MB_IsolationResult));
-       // Assert.Equals(2, results.Count(r => r is MB_Isolation));
+       Assert.That(35, Is.EqualTo(results.Count(r => r is MB_IsolationResult)));
+       Assert.That(2, Is.EqualTo(results.Count(r => r is MB_Isolation)));
 
 
     }
@@ -287,23 +287,23 @@ MB
 THOK1H
 ";
         var results = CreateReaderFromString(testString, true);
-       // Assert.Equals(6,results.Count);
+       Assert.That(6,Is.EqualTo(results.Count));
 
         var isolations = results.Where(r => r is MB_Isolation).Cast<MB_Isolation>().ToArray();
-       // Assert.Equals(2, isolations.Length);
+       Assert.That(2, Is.EqualTo(isolations.Length));
 
 
-       // Assert.Equals(0, results.Count(r => r is MB_IsolationResult));//should be no results because there are no "$SENS             S" etc bits
+       Assert.That(0, Is.EqualTo(results.Count(r => r is MB_IsolationResult)));//should be no results because there are no "$SENS             S" etc bits
 
-       // Assert.Equals("SAUR",isolations[0].organismCode );
-       // Assert.Equals("P", isolations[0].WeightGrowth_cd);
-       // Assert.Equals("Y",isolations[0].IntCode1);
-       // Assert.Equals("Y",isolations[0].IntCode2);
+       Assert.That("SAUR",Is.EqualTo(isolations[0].organismCode ));
+       Assert.That("P", Is.EqualTo(isolations[0].WeightGrowth_cd));
+       Assert.That("Y",Is.EqualTo(isolations[0].IntCode1));
+       Assert.That("Y",Is.EqualTo(isolations[0].IntCode2));
 
-       // Assert.Equals("BOBY",isolations[1].organismCode);
-       // Assert.Equals("Z",isolations[1].WeightGrowth_cd);
-       // Assert.Equals("N",isolations[1].IntCode1);
-       // Assert.Equals("N",isolations[1].IntCode2);
+       Assert.That("BOBY",Is.EqualTo(isolations[1].organismCode));
+       Assert.That("Z",Is.EqualTo(isolations[1].WeightGrowth_cd));
+       Assert.That("N",Is.EqualTo(isolations[1].IntCode1));
+       Assert.That("N",Is.EqualTo(isolations[1].IntCode2));
 
 
 
@@ -332,8 +332,8 @@ MB
 NG
 ";
         var results = CreateReaderFromString(testString, true);
-       // Assert.Equals(3, results.Count);
-       // Assert.Equals("LIKELY APPENDICITIS|PERSISTENT FEVER & SIRS|ON AMOX- GENT- METRO|###SENT IN WITHOUT FORM OR ICE REQUEST. DETAILS ON A HISTORY/CONTINUATION SHEET NP 11/11/11", ((MB_Lab)results.Single(r => r is MB_Lab)).Comments);
+       Assert.That(3, Is.EqualTo(results.Count));
+       Assert.That("LIKELY APPENDICITIS|PERSISTENT FEVER & SIRS|ON AMOX- GENT- METRO|###SENT IN WITHOUT FORM OR ICE REQUEST. DETAILS ON A HISTORY/CONTINUATION SHEET NP 11/11/11", Is.EqualTo(((MB_Lab)results.Single(r => r is MB_Lab)).Comments));
 
     }
 
@@ -377,7 +377,7 @@ MB
 LOVG1H
 ";
         var results = CreateReaderFromString(testString, true);
-       // Assert.Equals(11, results.Count);
+        Assert.That(11, Is.EqualTo(results.Count));
     }
 
     [Test]
@@ -425,9 +425,9 @@ The following record ids do not exist:
 
 ";
         var results = CreateReaderFromString(testString, true);
-       // Assert.Equals(11, results.Count);
-       // Assert.Equals("11:11",((MB_Lab)results.Single(r=>r is MB_Lab)).RcvTime);
-       // Assert.Equals("11:11", ((MB_Lab)results.Single(r => r is MB_Lab)).SampleTime);
+       Assert.That(11, Is.EqualTo(results.Count));
+       Assert.That("11:11",Is.EqualTo(((MB_Lab)results.Single(r=>r is MB_Lab)).RcvTime));
+       Assert.That("11:11", Is.EqualTo(((MB_Lab)results.Single(r => r is MB_Lab)).SampleTime));
     }
 
     [Test]
@@ -472,7 +472,7 @@ MB
 DYMT1G
 ";
         var results = CreateReaderFromString(testString, false);
-       // Assert.Equals(4,results.Count);
+       Assert.That(4,Is.EqualTo(results.Count));
     }
 
     [Test]
@@ -614,7 +614,7 @@ MB
 JOSJ1H
 ";
         var results = CreateReaderFromString(testString, false);
-       // Assert.Equals(90, results.Count);
+       Assert.That(90, Is.EqualTo(results.Count));
 
     }
 
@@ -689,12 +689,12 @@ MP
 SHEA1H";
         var results = CreateReaderFromString(testString, true);
 
-       // Assert.Equals(12,results.Count(r => r is MB_IsolationResult));
+       Assert.That(12,Is.EqualTo(results.Count(r => r is MB_IsolationResult)));
 
         var t = ((MB_Tests) results.FirstOrDefault(r => r is MB_Tests));
 
         Assert.That(t, Is.Not.Null);
-       // Assert.Equals("BLAN", t.TestCode);
+       Assert.That("BLAN", Is.EqualTo(t.TestCode));
 
     }
 }

--- a/HICPluginTests/Unit/MicrobiologyLoaderTests.cs
+++ b/HICPluginTests/Unit/MicrobiologyLoaderTests.cs
@@ -293,8 +293,7 @@ THOK1H
        Assert.That(2, Is.EqualTo(isolations.Length));
 
 
-       Assert.That(0, Is.EqualTo(results.Count(r => r is MB_IsolationResult)));//should be no results because there are no "$SENS             S" etc bits
-
+       Assert.That(0, Is.EqualTo(results.Count(r => r is MB_IsolationResult)));
        Assert.That("SAUR",Is.EqualTo(isolations[0].organismCode ));
        Assert.That("P", Is.EqualTo(isolations[0].WeightGrowth_cd));
        Assert.That("Y",Is.EqualTo(isolations[0].IntCode1));

--- a/HICPluginTests/Unit/PrimaryKeyRelatedTests.cs
+++ b/HICPluginTests/Unit/PrimaryKeyRelatedTests.cs
@@ -18,7 +18,7 @@ public class PrimaryKeyRelatedTests
         };
 
 
-        Assert.IsTrue(r1.IsIdenticalTo(r2));
+        Assert.That(r1.IsIdenticalTo(r2),Is.True);
     }
     [Test]
     public void TestIdenticallity_NotIdentical()
@@ -35,6 +35,6 @@ public class PrimaryKeyRelatedTests
         };
 
 
-        Assert.IsFalse(r1.IsIdenticalTo(r2));
+        Assert.That(r1.IsIdenticalTo(r2), Is.False);
     }
 }

--- a/HICPluginTests/Unit/RepositoryTests.cs
+++ b/HICPluginTests/Unit/RepositoryTests.cs
@@ -26,7 +26,7 @@ class RepositoryTests
         var bloodSample = report.Samples.First();
         var result = bloodSample.Results.First(static r => r.ReadCodeValue.Equals("TTTT."));
 
-        Assert.Equals(8.9, result.QuantityValue ?? 0.0m);
+       // Assert.Equals(8.9, result.QuantityValue ?? 0.0m);
     }
 
     [Test]
@@ -82,12 +82,12 @@ class RepositoryTests
             
         repo.Create(reports, listener);
 
-        Assert.Equals(1, repo.HeadersTable.Rows.Count);//, "HeadersTable doesn't have the correct number of rows");
-        Assert.Equals(1, repo.SampleDetailsTable.Rows.Count);//, "SampleDetailsTable doesn't have the correct number of rows");
-        Assert.Equals(2, repo.ResultsTable.Rows.Count);//, "ResultsTable doesn't have the correct number of rows");
+       // Assert.Equals(1, repo.HeadersTable.Rows.Count);//, "HeadersTable doesn't have the correct number of rows");
+       // Assert.Equals(1, repo.SampleDetailsTable.Rows.Count);//, "SampleDetailsTable doesn't have the correct number of rows");
+       // Assert.Equals(2, repo.ResultsTable.Rows.Count);//, "ResultsTable doesn't have the correct number of rows");
 
-        Assert.Equals("TESTID", repo.ResultsTable.Rows[0]["TestIdentifier"]);
-        Assert.Equals("ANOTHERTEST_LOCAL", repo.ResultsTable.Rows[1]["LocalClinicalCodeValue"]);
+       // Assert.Equals("TESTID", repo.ResultsTable.Rows[0]["TestIdentifier"]);
+       // Assert.Equals("ANOTHERTEST_LOCAL", repo.ResultsTable.Rows[1]["LocalClinicalCodeValue"]);
 
         Assert.That(repo.ResultsTable.Rows[0]["QuantityValue"].ToString().Length == 4,Is.True);// "The float value has not been correctly inserted into the data table. Original value was 2.1 (float), value in datatable is " + repo.ResultsTable.Rows[0]["QuantityValue"]);
     }
@@ -105,7 +105,7 @@ class RepositoryTests
 
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(badXmlString));
         var actualString = CombinedReportXmlDeserializer.RemoveInvalidCharactersFromStream(stream);
-        Assert.Equals(expectedXmlString, actualString);
+       // Assert.Equals(expectedXmlString, actualString);
     }
 }
 

--- a/HICPluginTests/Unit/RepositoryTests.cs
+++ b/HICPluginTests/Unit/RepositoryTests.cs
@@ -26,7 +26,7 @@ class RepositoryTests
         var bloodSample = report.Samples.First();
         var result = bloodSample.Results.First(static r => r.ReadCodeValue.Equals("TTTT."));
 
-       // Assert.Equals(8.9, result.QuantityValue ?? 0.0m);
+       Assert.That(8.9, Is.EqualTo(result.QuantityValue ?? 0.0m));
     }
 
     [Test]
@@ -82,12 +82,12 @@ class RepositoryTests
             
         repo.Create(reports, listener);
 
-       // Assert.Equals(1, repo.HeadersTable.Rows.Count);//, "HeadersTable doesn't have the correct number of rows");
-       // Assert.Equals(1, repo.SampleDetailsTable.Rows.Count);//, "SampleDetailsTable doesn't have the correct number of rows");
-       // Assert.Equals(2, repo.ResultsTable.Rows.Count);//, "ResultsTable doesn't have the correct number of rows");
+       Assert.That(1, Is.EqualTo(repo.HeadersTable.Rows.Count));//, "HeadersTable doesn't have the correct number of rows");
+       Assert.That(1, Is.EqualTo(repo.SampleDetailsTable.Rows.Count));//, "SampleDetailsTable doesn't have the correct number of rows");
+       Assert.That(2, Is.EqualTo(repo.ResultsTable.Rows.Count));//, "ResultsTable doesn't have the correct number of rows");
 
-       // Assert.Equals("TESTID", repo.ResultsTable.Rows[0]["TestIdentifier"]);
-       // Assert.Equals("ANOTHERTEST_LOCAL", repo.ResultsTable.Rows[1]["LocalClinicalCodeValue"]);
+       Assert.That("TESTID", Is.EqualTo(repo.ResultsTable.Rows[0]["TestIdentifier"]));
+       Assert.That("ANOTHERTEST_LOCAL", Is.EqualTo(repo.ResultsTable.Rows[1]["LocalClinicalCodeValue"]));
 
         Assert.That(repo.ResultsTable.Rows[0]["QuantityValue"].ToString().Length == 4,Is.True);// "The float value has not been correctly inserted into the data table. Original value was 2.1 (float), value in datatable is " + repo.ResultsTable.Rows[0]["QuantityValue"]);
     }
@@ -105,7 +105,7 @@ class RepositoryTests
 
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(badXmlString));
         var actualString = CombinedReportXmlDeserializer.RemoveInvalidCharactersFromStream(stream);
-       // Assert.Equals(expectedXmlString, actualString);
+       Assert.That(expectedXmlString, Is.EqualTo(actualString));
     }
 }
 

--- a/HICPluginTests/Unit/RepositoryTests.cs
+++ b/HICPluginTests/Unit/RepositoryTests.cs
@@ -26,7 +26,7 @@ class RepositoryTests
         var bloodSample = report.Samples.First();
         var result = bloodSample.Results.First(static r => r.ReadCodeValue.Equals("TTTT."));
 
-        Assert.AreEqual(8.9, result.QuantityValue ?? 0.0m);
+        Assert.Equals(8.9, result.QuantityValue ?? 0.0m);
     }
 
     [Test]
@@ -82,14 +82,14 @@ class RepositoryTests
             
         repo.Create(reports, listener);
 
-        Assert.AreEqual(1, repo.HeadersTable.Rows.Count, "HeadersTable doesn't have the correct number of rows");
-        Assert.AreEqual(1, repo.SampleDetailsTable.Rows.Count, "SampleDetailsTable doesn't have the correct number of rows");
-        Assert.AreEqual(2, repo.ResultsTable.Rows.Count, "ResultsTable doesn't have the correct number of rows");
+        Assert.Equals(1, repo.HeadersTable.Rows.Count);//, "HeadersTable doesn't have the correct number of rows");
+        Assert.Equals(1, repo.SampleDetailsTable.Rows.Count);//, "SampleDetailsTable doesn't have the correct number of rows");
+        Assert.Equals(2, repo.ResultsTable.Rows.Count);//, "ResultsTable doesn't have the correct number of rows");
 
-        Assert.AreEqual("TESTID", repo.ResultsTable.Rows[0]["TestIdentifier"]);
-        Assert.AreEqual("ANOTHERTEST_LOCAL", repo.ResultsTable.Rows[1]["LocalClinicalCodeValue"]);
+        Assert.Equals("TESTID", repo.ResultsTable.Rows[0]["TestIdentifier"]);
+        Assert.Equals("ANOTHERTEST_LOCAL", repo.ResultsTable.Rows[1]["LocalClinicalCodeValue"]);
 
-        Assert.IsTrue(repo.ResultsTable.Rows[0]["QuantityValue"].ToString().Length == 4, "The float value has not been correctly inserted into the data table. Original value was 2.1 (float), value in datatable is " + repo.ResultsTable.Rows[0]["QuantityValue"]);
+        Assert.That(repo.ResultsTable.Rows[0]["QuantityValue"].ToString().Length == 4,Is.True);// "The float value has not been correctly inserted into the data table. Original value was 2.1 (float), value in datatable is " + repo.ResultsTable.Rows[0]["QuantityValue"]);
     }
 
     [Test]
@@ -105,7 +105,7 @@ class RepositoryTests
 
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(badXmlString));
         var actualString = CombinedReportXmlDeserializer.RemoveInvalidCharactersFromStream(stream);
-        Assert.AreEqual(expectedXmlString, actualString);
+        Assert.Equals(expectedXmlString, actualString);
     }
 }
 

--- a/HICPluginTests/Unit/RepositoryTests.cs
+++ b/HICPluginTests/Unit/RepositoryTests.cs
@@ -82,14 +82,14 @@ class RepositoryTests
             
         repo.Create(reports, listener);
 
-       Assert.That(1, Is.EqualTo(repo.HeadersTable.Rows.Count));//, "HeadersTable doesn't have the correct number of rows");
-       Assert.That(1, Is.EqualTo(repo.SampleDetailsTable.Rows.Count));//, "SampleDetailsTable doesn't have the correct number of rows");
-       Assert.That(2, Is.EqualTo(repo.ResultsTable.Rows.Count));//, "ResultsTable doesn't have the correct number of rows");
+       Assert.That(1, Is.EqualTo(repo.HeadersTable.Rows.Count));
+       Assert.That(1, Is.EqualTo(repo.SampleDetailsTable.Rows.Count));
+       Assert.That(2, Is.EqualTo(repo.ResultsTable.Rows.Count));
 
        Assert.That("TESTID", Is.EqualTo(repo.ResultsTable.Rows[0]["TestIdentifier"]));
        Assert.That("ANOTHERTEST_LOCAL", Is.EqualTo(repo.ResultsTable.Rows[1]["LocalClinicalCodeValue"]));
 
-        Assert.That(repo.ResultsTable.Rows[0]["QuantityValue"].ToString().Length == 4,Is.True);// "The float value has not been correctly inserted into the data table. Original value was 2.1 (float), value in datatable is " + repo.ResultsTable.Rows[0]["QuantityValue"]);
+        Assert.That(repo.ResultsTable.Rows[0]["QuantityValue"].ToString().Length == 4, Is.True);
     }
 
     [Test]

--- a/SCIStorePlugin/Repositories/ReflectionBasedSqlDatabaseInserter.cs
+++ b/SCIStorePlugin/Repositories/ReflectionBasedSqlDatabaseInserter.cs
@@ -131,7 +131,7 @@ public static class ReflectionBasedSqlDatabaseInserter
 
                         if (lengthInDatabase < s.Length)
                             problemsDetected +=
-                                $"Column {column} in table {tableName} is defined as length  {lengthInDatabase} in the database but you tried to insert a string value of length {s.Length}{Environment.NewLine}";
+                                $"Column {column} in table {tableName} is defined as length {lengthInDatabase} in the database but you tried to insert a string value of length {s.Length}{Environment.NewLine}";
                     }
                 }
 

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -10,6 +10,6 @@
 [assembly: AssemblyCulture("")]
 
 // These should be overwritten by release builds
-[assembly: AssemblyVersion("6.1.1")]
-[assembly: AssemblyFileVersion("6.1.1")]
-[assembly: AssemblyInformationalVersion("6.1.1")]
+[assembly: AssemblyVersion("6.1.2")]
+[assembly: AssemblyFileVersion("6.1.2")]
+[assembly: AssemblyInformationalVersion("6.1.2")]


### PR DESCRIPTION
## Changes
* Updates tests to the latest version of NUnit provided by RDMP
* Adds documentation for the CHI Coulmn finder
* Adds a sample AllowList for the CHI Column Finder
* Hardens the CHI Column Finder to not crash when parsing junk CHIs
*Update FoundChi extraction location to be the root extraction folder, not the specific extraction folder

## Solution
A user was passing UIDs into the CHI column finder, such as "1896911d-7148-4bc2-8dc2-ddb371240550", which contains a 9 character substring that looks like a CHI. This caused us to try and grab the 10 digit CHI from String[string.length-9,String.Length+1] which caused the CHI column finder to crash. Some hardening has been done to prevent attempting to pull substrings that are out of bounds

## How to test
You can set up and extraction with the CHI column finder and attempt to extract quasi-CHIs in an attempt to break it, but it will be quicker and easier to add any values you want to testy into the CHI list in the CHIColumnFinderTests.cs file
