### PR TITLE
Remove rule Biochem must start C or POC, no longer valid

### DIFF
--- a/SCIStorePlugin/Data/SciStoreHeader.cs
+++ b/SCIStorePlugin/Data/SciStoreHeader.cs
@@ -119,11 +119,6 @@ public static class SciStoreHeaderFactory
         var report = combinedReport.InvestigationReport;
         var reportData = report.ReportData;
 
-        if (reportData.Discipline.Equals("Biochemistry")
-            && !combinedReportHeader.LabNumber.StartsWith("C")
-            && !combinedReportHeader.LabNumber.StartsWith("POC"))
-            throw new Exception($"Malformed (or otherwise unexpected) LabNumber: {combinedReportHeader.LabNumber}");
-
         var labNumber = combinedReportHeader.LabNumber;
             
         if (labNumber.Length <= 10) return labNumber;


### PR DESCRIPTION
Fife Scilab feed does not match these criteria, so remove them to avoid rejecting valid data in error.